### PR TITLE
Debug log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ near_tests.wasm
 errors.wasm
 jsvm.wasm
 *.base64
+jsvm_nightly.wasm
+jsvm_nightly_sandbox.wasm
+jsvm_sandbox.wasm
 
 .vscode

--- a/build.sh
+++ b/build.sh
@@ -6,11 +6,21 @@ WASI_SDK_PATH=${SCRIPT_DIR}/vendor/wasi-sdk-11.0
 CC="${WASI_SDK_PATH}/bin/clang --sysroot=${WASI_SDK_PATH}/share/wasi-sysroot"
 QUICKJS_SRC_DIR=${SCRIPT_DIR}/quickjs
 WASI_STUB=${SCRIPT_DIR}/vendor/binaryen/wasi-stub/run.sh
+TARGET_NAME=jsvm
 
 DEFS='-D_GNU_SOURCE -DCONFIG_VERSION="2021-03-27" -DCONFIG_BIGNUM'
-if [[ -z NEAR_NIGHTLY ]]; then
+set +u
+if [[ -n "${NEAR_NIGHTLY}" ]]; then
   DEFS+=' -DNIGHTLY'
+  TARGET_NAME+='_nightly'
 fi
+if [[ -n "${NEAR_SANDBOX}" ]]; then
+  DEFS+=' -DSANDBOX'
+  TARGET_NAME+='_sandbox'
+fi
+set -u
+TARGET_NAME+='.wasm'
+
 INCLUDES="-I${SCRIPT_DIR}/stubs -I${QUICKJS_SRC_DIR} -I."
 LIBS='-lm'
 QUICKJS_SOURCES=(quickjs.c libregexp.c libunicode.c cutils.c quickjs-libc-min.c libbf.c)
@@ -27,6 +37,6 @@ $CC --target=wasm32-wasi \
     -Wl,--allow-undefined \
     -Wl,-z,stack-size=$[256 * 1024] \
     -Wl,--lto-O3 \
-    -o jsvm.wasm
+    -o ${TARGET_NAME}
 
-${WASI_STUB} jsvm.wasm >/dev/null
+${WASI_STUB} ${TARGET_NAME} >/dev/null

--- a/examples/debug_log.js
+++ b/examples/debug_log.js
@@ -1,0 +1,3 @@
+export function test_debug_log() {
+    debug.log('this will be in sandbox log')
+}

--- a/jsvm.c
+++ b/jsvm.c
@@ -1087,8 +1087,8 @@ static JSValue near_alt_bn128_pairing_check(JSContext *ctx, JSValueConst this_va
 }
 #endif
 
-#ifdef SANDBOX
 static JSValue near_debug_log(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+#ifdef SANDBOX
 {
   const char *data_ptr;
   size_t data_len;
@@ -1096,6 +1096,10 @@ static JSValue near_debug_log(JSContext *ctx, JSValueConst this_val, int argc, J
   data_ptr = JS_ToCStringLen(ctx, &data_len, argv[0]);
   
   debug_log(data_len, (uint64_t)data_ptr);
+  return JS_UNDEFINED;
+}
+#else
+{
   return JS_UNDEFINED;
 }
 #endif
@@ -1161,12 +1165,9 @@ static void js_add_near_host_functions(JSContext* ctx) {
 
   JS_SetPropertyStr(ctx, global_obj, "env", env);
 
-#ifdef SANDBOX
   JSValue debug = JS_NewObject(ctx);
   JS_SetPropertyStr(ctx, debug, "log", JS_NewCFunction(ctx, near_debug_log, "log", 1));
   JS_SetPropertyStr(ctx, global_obj, "debug", debug);
-#endif
-
 }
 
 JSValue JS_Call(JSContext *ctx, JSValueConst func_obj, JSValueConst this_obj,

--- a/jsvm.c
+++ b/jsvm.c
@@ -110,7 +110,7 @@ extern uint64_t alt_bn128_pairing_check(uint64_t value_len, uint64_t value_ptr);
 // #  Sandbox  #
 // #############
 #ifdef SANDBOX
-extern void debug_log(uint64_t len, uint64_t ptr);
+extern void sandbox_debug_log(uint64_t len, uint64_t ptr);
 #endif
 
 static JSValue near_read_register(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
@@ -1095,7 +1095,7 @@ static JSValue near_debug_log(JSContext *ctx, JSValueConst this_val, int argc, J
 
   data_ptr = JS_ToCStringLen(ctx, &data_len, argv[0]);
   
-  debug_log(data_len, (uint64_t)data_ptr);
+  sandbox_debug_log(data_len, (uint64_t)data_ptr);
   return JS_UNDEFINED;
 }
 #else

--- a/jsvm.c
+++ b/jsvm.c
@@ -106,6 +106,12 @@ extern void alt_bn128_g1_multiexp(uint64_t value_len, uint64_t value_ptr, uint64
 extern void alt_bn128_g1_sum(uint64_t value_len, uint64_t value_ptr, uint64_t register_id);
 extern uint64_t alt_bn128_pairing_check(uint64_t value_len, uint64_t value_ptr);
 #endif
+// #############
+// #  Sandbox  #
+// #############
+#ifdef SANDBOX
+extern void debug_log(uint64_t len, uint64_t ptr);
+#endif
 
 static JSValue near_read_register(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
 {
@@ -1081,6 +1087,19 @@ static JSValue near_alt_bn128_pairing_check(JSContext *ctx, JSValueConst this_va
 }
 #endif
 
+#ifdef SANDBOX
+static JSValue near_debug_log(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  const char *data_ptr;
+  size_t data_len;
+
+  data_ptr = JS_ToCStringLen(ctx, &data_len, argv[0]);
+  
+  debug_log(data_len, (uint64_t)data_ptr);
+  return JS_UNDEFINED;
+}
+#endif
+
 static void js_add_near_host_functions(JSContext* ctx) {
   JSValue global_obj, env;
 
@@ -1141,6 +1160,13 @@ static void js_add_near_host_functions(JSContext* ctx) {
   JS_SetPropertyStr(ctx, env, "jsvm_call", JS_NewCFunction(ctx, near_jsvm_call, "jsvm_call", 4));
 
   JS_SetPropertyStr(ctx, global_obj, "env", env);
+
+#ifdef SANDBOX
+  JSValue debug = JS_NewObject(ctx);
+  JS_SetPropertyStr(ctx, debug, "log", JS_NewCFunction(ctx, near_debug_log, "log", 1));
+  JS_SetPropertyStr(ctx, global_obj, "debug", debug);
+#endif
+
 }
 
 JSValue JS_Call(JSContext *ctx, JSValueConst func_obj, JSValueConst this_obj,

--- a/readme.md
+++ b/readme.md
@@ -367,3 +367,8 @@ User can use verror this way:
 3. throw the final verror, `throw e`, same as in nodejs.
 
 Under the hood, our quickjs runtime would take the final throwed error, and invoke panic_utf8("{error.message}\n{error.stack}")
+
+## Debug and Test
+To get more debug utilities, such as debug print (`debug.log`) and logging stacktrace, you can build JSVM with sandbox flag: `NEAR_SANDBOX=1 ./build.sh`. A `jsvm_sandbox.wasm` will be build in current directory. You can then deploy sandbox versioned jsvm to a local [near-sandbox](https://github.com/near/sandbox). near-sandbox can be launched either manually or via the official testing framework [near-workspaces](https://github.com/near/workspaces-js). We recommend to use near-workspaces to write tests for your smart contracts. An example of use near-workspaces in a JS contract project can be found in `examples/project/`. 
+
+Note that, `jsvm.wasm` can be used for sandbox/near-workspaces as well. But to debug print, you need to use `jsvm_sandbox.wasm` instead.


### PR DESCRIPTION
Add debug log feature for jsvm_sandbox. Update build script to build different configure into different `jsvm_*.wasm`. Add an example to test debug log. Update documentation.

This feature will only be available if near/nearcore#6324 is accepted