### PR TITLE
Fix bad design that nested call/view override state

### DIFF
--- a/examples/template/index.js
+++ b/examples/template/index.js
@@ -23,5 +23,19 @@ class Counter extends NearContract {
     getCount() {
         return this.count
     }
+
+    @call
+    series(...numbers) {
+        for(let n of numbers) {
+            env.log(`Counter at ${this.getCount()}`)
+            if (n > 0) {
+                env.log(`Counter increase ${n}`)
+                this.increase(n)
+            } else if (n < 0) {
+                env.log(`Counter decrease ${-n}`)
+                this.decrease(-n)
+            }
+        }
+    }
 }
 

--- a/sdk/near-bindgen-exporter.js
+++ b/sdk/near-bindgen-exporter.js
@@ -25,10 +25,30 @@ export default function () {
             path.insertAfter(
               t.exportNamedDeclaration(
                 t.functionDeclaration(t.identifier(method), [], t.blockStatement([
+                  // let _contract = ContractClass._get()
                   t.variableDeclaration('let', [t.variableDeclarator(t.identifier('_contract'), 
                     t.callExpression(t.memberExpression(classId, t.identifier('_get')), []))]),
+                  // _contract.deserialize()
                   t.expressionStatement(
-                    t.callExpression(t.memberExpression(t.identifier('_contract'), t.identifier(method)), [])),
+                    t.callExpression(t.memberExpression(t.identifier('_contract'), t.identifier('deserialize')), [])),
+                  // let args = _contract.constructor.deserializeArgs()
+                  t.variableDeclaration('let', [t.variableDeclarator(t.identifier('args'), 
+                    t.callExpression(t.memberExpression(t.memberExpression(t.identifier('_contract'), t.identifier('constructor')), t.identifier('deserializeArgs')), []))]),
+                  // let ret = _contract.method(...args)
+                  t.variableDeclaration('let', [t.variableDeclarator(t.identifier('ret'), 
+                    t.callExpression(t.memberExpression(t.identifier('_contract'), t.identifier(method)), [t.spreadElement(t.identifier('args'))]))]),
+                  contractMethods[method] == 'call' ?
+                    // _contract.serialize()
+                    t.expressionStatement(
+                      t.callExpression(t.memberExpression(t.identifier('_contract'), t.identifier('serialize')), []))
+                    : t.emptyStatement(),
+                  // if (ret !== undefined)
+                  t.ifStatement(t.binaryExpression('!==', t.identifier('ret'), t.identifier('undefined')),
+                    // env.jsvm_value_return(_contract.constructor.serializeReturn(ret))
+                    t.expressionStatement(t.callExpression(t.memberExpression(t.identifier('env'), t.identifier('jsvm_value_return')), [
+                      t.callExpression(t.memberExpression(t.memberExpression(t.identifier('_contract'), t.identifier('constructor')), t.identifier('serializeReturn')), [t.identifier('ret')])
+                    ]))
+                  )
                 ])),
                 [t.exportSpecifier(t.identifier(method), t.identifier(method))]))
           }

--- a/sdk/near-bindgen.js
+++ b/sdk/near-bindgen.js
@@ -1,27 +1,8 @@
 export function call (target, name, descriptor) {
-    let oldMethod = descriptor.value
-    descriptor.value = function() {
-        target.deserialize()
-        let args = target.constructor.deserializeArgs()
-        let ret = oldMethod.apply(target, args)
-        target.serialize()
-        if (ret !== undefined) {
-            env.jsvm_value_return(target.constructor.serializeReturn(ret))
-        }
-    }
     return descriptor
 }
 
 export function view (target, name, descriptor) {
-    let oldMethod = descriptor.value
-    descriptor.value = function() {
-        target.deserialize()
-        let args = target.constructor.deserializeArgs()
-        let ret = oldMethod.apply(target, args)
-        if (ret !== undefined) {
-            env.jsvm_value_return(target.constructor.serializeReturn(ret))
-        }
-    }
     return descriptor
 }
 


### PR DESCRIPTION
Thanks @BenKurrek to find out this bad design: nested `@call/@view` will reset the contract state, making them not composable. This PR fix this problem by:
- doesn't do anything to modify user's `@call/@view` methods, these are just markers. So `@call/@view` are just normal method that can be reused and composed like any other method.
- code generation functions that has same name as the method, which does deserialize/call/serialize/return

I can confirm this is the behavior of rust sdk and update examples in this PR shows the expected behavior:

```
near-sdk-js (master) near call test.near call_js_contract --accountId test.near --base64 --args $(node encode_call.js test.near series '[3, -2, 10, -5]') --deposit 0.1
Scheduling a call: test.near.call_js_contract(dGVzdC5uZWFyAHNlcmllcwBbMywgLTIsIDEwLCAtNV0=) with attached 0.1 NEAR
Loaded master account test.near key from /Users/bo/.near/validator_key.json with public key = ed25519:14tLxTVu21BanAv2gNs2nLKw8JPCe6Xp9Has2Q4sbwQu
Doing account.functionCall()
Receipts: DJzrZwrpfWBC72i2tBH2PP6kc2pDkFKUgbi6nWkVsXe1, D7ECkDdN7m9TMzgU9LFFf7Pe1F2k3spgcpndDe5yDX9e
	Log [test.near]: Counter at 30
	Log [test.near]: Counter increase 3
	Log [test.near]: Counter increased to 33
	Log [test.near]: Counter at 33
	Log [test.near]: Counter decrease 2
	Log [test.near]: Counter decreased to 31
	Log [test.near]: Counter at 31
	Log [test.near]: Counter increase 10
	Log [test.near]: Counter increased to 41
	Log [test.near]: Counter at 41
	Log [test.near]: Counter decrease 5
	Log [test.near]: Counter decreased to 36
Transaction Id 2TFmXkFuZskAzm6UobYvL7xBGTaKZj5W1MYcRibBmPU6
```