### PR TITLE
Fix the bug that after cross contract call, jsvm_storage_write write to callee contract

### DIFF
--- a/sdk/api.js
+++ b/sdk/api.js
@@ -120,6 +120,6 @@ export function jsvmStorageHasKey(key) {
 }
 
 export function jsvmCall(contractName, method, args) {
-    env.jsvm_call(contractName, method, args, 0)
-    return env.read_register(0)
+    env.jsvm_call(contractName, method, JSON.stringify(args), 0)
+    return JSON.parse(env.read_register(0) || 'null')
 }

--- a/sdk/api.js
+++ b/sdk/api.js
@@ -40,7 +40,7 @@ export function ripemd160(value) {
 
 export function ecrecover(hash, sign, v, malleabilityFlag) {
     let ret = env.ecrecover(hash, sign, v, malleabilityFlag, 0)
-    if (ret === 0) {
+    if (ret === 0n) {
         return null
     }
     return env.read_register(0)
@@ -50,7 +50,7 @@ export function ecrecover(hash, sign, v, malleabilityFlag) {
 
 export function storageRead(key) {
     let ret = env.storage_read(key, 0)
-    if (ret === 1) {
+    if (ret === 1n) {
         return env.read_register(0)
     } else {
         return null
@@ -89,7 +89,7 @@ export function jsvmArgs() {
 
 export function jsvmStorageWrite(key, value) {
     let exist = env.jsvm_storage_write(key, value, 0)
-    if (exist === 1) {
+    if (exist === 1n) {
         return true
     }
     return false
@@ -97,7 +97,7 @@ export function jsvmStorageWrite(key, value) {
 
 export function jsvmStorageRead(key) {
     let exist = env.jsvm_storage_read(key, 0)
-    if (exist === 1) {
+    if (exist === 1n) {
         return env.read_register(0)
     }
     return null
@@ -105,7 +105,7 @@ export function jsvmStorageRead(key) {
 
 export function jsvmStorageRemove(key) {
     let exist = env.jsvm_storage_remove(key, 0)
-    if (exist === 1) {
+    if (exist === 1n) {
         return true
     }
     return false
@@ -113,7 +113,7 @@ export function jsvmStorageRemove(key) {
 
 export function jsvmStorageHasKey(key) {
     let exist = env.jsvm_storage_has_key(key)
-    if (exist === 1) {
+    if (exist === 1n) {
         return true
     }
     return false


### PR DESCRIPTION
This bug result in state not updating after a cross contract call (actually it's even worse, it wrote to the wrong contract). After the fix, state write after cross contract call is writing to the correct place (caller contract). 

Also fix several api function, where it returns BigUint64 (JS BigInt) instead of Number.

And add stringify and parse to cross contract call args to simplify developer's work. Developer can now do:
```
let available = near.jsvmCall('status-message.test.near', 'get_status', [accountId])
// available is "AVIALABLE" instead of '"AVAILABLE"'
```

~Also optimize to reuse the quickjs instance to do cross contract call. Should save some wasm instructions and therefore gas.~
Update: we can't do this, because otherwise user can modify `env.` host functions, then reuse quickjs would use modified version, cause security attacks.