### PR TITLE
Add status message collections example

### DIFF
--- a/examples/status-message-collections/.gitignore
+++ b/examples/status-message-collections/.gitignore
@@ -1,0 +1,2 @@
+build
+node_modules

--- a/examples/status-message-collections/README.md
+++ b/examples/status-message-collections/README.md
@@ -1,0 +1,18 @@
+# Status message contract in JavaScript
+
+This is an JavaScript implementation of the status message collections example. Every user can store a message on chain. Every user can view everyone's message. It is also intended to test SDK collections.
+
+## Build the contract
+
+First ensure JSVM contract is build and deployed locally, follow [Local Installation](https://github.com/near/near-sdk-js#local-installation). Then run:
+```
+npm i
+npm run build
+```
+
+Result contract bytecode file will be in `build/contract.base64`. Intermediate JavaScript file can be found in `build/contract.js`. You'll only need the `base64` file to deploy contract to chain. The intermediate JavaScript file is for curious user and near-sdk-js developers to understand what code generation happened under the hood.
+
+## Test the contract with workspaces-js
+```
+npm run test
+```

--- a/examples/status-message-collections/ava.config.cjs
+++ b/examples/status-message-collections/ava.config.cjs
@@ -1,0 +1,8 @@
+require('util').inspect.defaultOptions.depth = 5; // Increase AVA's printing depth
+
+module.exports = {
+  timeout: '300000',
+  files: ['**/*.ava.js'],
+  failWithoutAssertions: false,
+  extensions: ['js'],
+};

--- a/examples/status-message-collections/babel.config.json
+++ b/examples/status-message-collections/babel.config.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "near-sdk-js/src/build-tools/near-bindgen-exporter",
+    ["@babel/plugin-proposal-decorators", {"version": "legacy"}]
+  ]
+}

--- a/examples/status-message-collections/package.json
+++ b/examples/status-message-collections/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "status-message-collections",
+  "version": "1.0.0",
+  "description": "Status message collections example with near-sdk-js",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "build": "near-sdk build",
+    "test": "ava"
+  },
+  "author": "Near Inc <hello@nearprotocol.com>",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "near-sdk-js": "file:../../"
+  },
+  "devDependencies": {
+    "ava": "^4.2.0",
+    "near-workspaces": "^2.0.0"
+  }
+}

--- a/examples/status-message-collections/src/index.js
+++ b/examples/status-message-collections/src/index.js
@@ -1,0 +1,45 @@
+import {NearContract, NearBindgen, call, view, near, LookupSet, UnorderedMap, Vector} from 'near-sdk-js'
+
+@NearBindgen
+class StatusMessage extends NearContract {
+    constructor() {
+        super()
+        this.records = new UnorderedMap('a')
+        this.uniqueValues = new LookupSet('b')
+    }
+
+    deserialize() {
+        super.deserialize()
+        this.records.keys = Object.assign(new Vector, this.records.keys)
+        this.records.values = Object.assign(new Vector, this.records.values)
+        this.records = Object.assign(new UnorderedMap, this.records)
+        this.uniqueValues = Object.assign(new LookupSet, this.uniqueValues)
+    }
+
+    @call
+    set_status(message) {
+        let account_id = near.signerAccountId()
+        env.log(`${account_id} set_status with message ${message}`)
+        this.records.set(account_id, message)
+        this.uniqueValues.set(message)
+    }
+
+    @view
+    get_status(account_id) {
+        env.log(`get_status for account_id ${account_id}`)
+        return this.records.get(account_id)
+    }
+
+    @view
+    has_status(message) {
+        // used for test LookupMap
+        return this.uniqueValues.contains(message)
+    }
+
+    @view
+    get_all_statuses() {
+        // used for test UnorderedMap
+        return this.records.toArray()
+    }
+}
+

--- a/examples/status-message/src/index.js
+++ b/examples/status-message/src/index.js
@@ -17,7 +17,7 @@ class StatusMessage extends NearContract {
     @view
     get_status(account_id) {
         env.log(`get_status for account_id ${account_id}`)
-        return this.records[account_id]
+        return this.records[account_id] || null
     }
 }
 

--- a/src/collections/vector.js
+++ b/src/collections/vector.js
@@ -29,7 +29,7 @@ export class Vector {
 
     get(index) {
         if (index >= this.length) {
-            return None
+            return null
         }
         let storageKey = this.indexToKey(index)
         return near.jsvmStorageRead(storageKey)


### PR DESCRIPTION
This also tested basic functionality of LookupSet and UnorderedMap (therefore also indirectly Vector), but not full. If intend to test all the features, it doesn’t quite fit into the status message example. So we would either have separate workspace test to test high level APIs, or test it in a better way as discussed in #51 