### PR TITLE
Allow to pass arguments as a dictionarry

### DIFF
--- a/tests/__tests__/function-params.ava.js
+++ b/tests/__tests__/function-params.ava.js
@@ -1,0 +1,65 @@
+import { Worker } from 'near-workspaces';
+import { readFile } from 'fs/promises'
+import test from 'ava';
+
+function encodeCall(contract, method, args) {
+    return Buffer.concat([Buffer.from(contract), Buffer.from([0]), Buffer.from(method), Buffer.from([0]), Buffer.from(JSON.stringify(args))])
+}
+
+test.beforeEach(async t => {
+    // Init the worker and start a Sandbox server
+    const worker = await Worker.init();
+
+    // Prepare sandbox for tests, create accounts, deploy contracts, etx.
+    const root = worker.rootAccount;
+
+    // Deploy the jsvm contract.
+    const jsvm = await root.createAndDeploy(
+        root.getSubAccount('jsvm').accountId,
+        '../res/jsvm.wasm',
+    );
+
+    // Deploy test JS contract
+    const testContract = await root.createSubAccount('test-contract');
+    let contract_base64 = (await readFile('build/function-params.base64')).toString();
+    await testContract.call(jsvm, 'deploy_js_contract', Buffer.from(contract_base64, 'base64'), { attachedDeposit: '400000000000000000000000' });
+    await testContract.call(jsvm, 'call_js_contract', encodeCall(testContract.accountId, 'init', []), { attachedDeposit: '400000000000000000000000' });
+
+    // Test users
+    const ali = await root.createSubAccount('ali');
+    const bob = await root.createSubAccount('bob');
+    const carl = await root.createSubAccount('carl');
+
+    // Save state for test runs
+    t.context.worker = worker;
+    t.context.accounts = { root, jsvm, testContract, ali, bob, carl };
+});
+
+test.afterEach(async t => {
+    await t.context.worker.tearDown().catch(error => {
+        console.log('Failed to tear down the worker:', error);
+    });
+});
+
+
+// test('Developer can pass parameters as dictionary', async t => {
+//     const { ali, jsvm, testContract } = t.context.accounts;
+
+//     await ali.call(jsvm, 'call_js_contract', encodeCall(testContract.accountId, 'set_values', ['newVal1', 'newVal2', 'newVal3']), { attachedDeposit: '100000000000000000000000' });
+
+//     t.is(
+//         await jsvm.view('view_js_contract', encodeCall(testContract.accountId, 'get_values', [])),
+//         { val3: this.newVal1, val2: this.newVal2, val1: this.newVal3 }
+//     );
+// });
+
+test('Developer can pass parameters as array', async t => {
+    const { ali, jsvm, testContract } = t.context.accounts;
+
+    await ali.call(jsvm, 'call_js_contract', encodeCall(testContract.accountId, 'set_values', ['newVal1', 'newVal2', 'newVal3']), { attachedDeposit: '100000000000000000000000' });
+
+    t.deepEqual(
+        await jsvm.view('view_js_contract', encodeCall(testContract.accountId, 'get_values', [])),
+        { val3: 'newVal3', val2: 'newVal2', val1: 'newVal1' }
+    );
+});

--- a/tests/__tests__/function-params.ava.js
+++ b/tests/__tests__/function-params.ava.js
@@ -42,16 +42,16 @@ test.afterEach(async t => {
 });
 
 
-// test('Developer can pass parameters as dictionary', async t => {
-//     const { ali, jsvm, testContract } = t.context.accounts;
+test('Developer can pass parameters as dictionary', async t => {
+    const { ali, jsvm, testContract } = t.context.accounts;
 
-//     await ali.call(jsvm, 'call_js_contract', encodeCall(testContract.accountId, 'set_values', ['newVal1', 'newVal2', 'newVal3']), { attachedDeposit: '100000000000000000000000' });
+    await ali.call(jsvm, 'call_js_contract', encodeCall(testContract.accountId, 'set_values', { param1: 'newVal1', param2: 'newVal2', param3: 'newVal3' }), { attachedDeposit: '100000000000000000000000' });
 
-//     t.is(
-//         await jsvm.view('view_js_contract', encodeCall(testContract.accountId, 'get_values', [])),
-//         { val3: this.newVal1, val2: this.newVal2, val1: this.newVal3 }
-//     );
-// });
+    t.deepEqual(
+        await jsvm.view('view_js_contract', encodeCall(testContract.accountId, 'get_values', {})),
+        { val3: 'newVal3', val2: 'newVal2', val1: 'newVal1' }
+    );
+});
 
 test('Developer can pass parameters as array', async t => {
     const { ali, jsvm, testContract } = t.context.accounts;

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -6,3 +6,4 @@ near-sdk build src/vector.js build/vector.base64
 near-sdk build src/lookup-map.js build/lookup-map.base64
 near-sdk build src/lookup-set.js build/lookup-set.base64
 near-sdk build src/unordered-set.js build/unordered-set.base64
+near-sdk build src/function-params.js build/function-params.base64

--- a/tests/src/function-params.js
+++ b/tests/src/function-params.js
@@ -1,0 +1,33 @@
+import {
+    NearContract,
+    NearBindgen,
+    call,
+    view,
+    near,
+} from 'near-sdk-js'
+
+/**
+ * Simple contract to test function parameters
+ */
+@NearBindgen
+class FunctionParamsTestContract extends NearContract {
+    constructor() {
+        super()
+        this.val1 = 'default1';
+        this.val2 = 'default2';
+        this.val3 = 'default3';
+    }
+
+    @call
+    set_values(param1, param2, param3) {
+        near.log(JSON.stringify({ param1, param2, param3 }));
+        this.val1 = param1;
+        this.val2 = param2;
+        this.val3 = param3;
+    }
+
+    @view
+    get_values() {
+        return { val3: this.val3, val2: this.val2, val1: this.val1 }
+    }
+}


### PR DESCRIPTION
Before:
```JS
await ali.call(jsvm, 'call_js_contract', encodeCall(testContract.accountId, 'set_values', ['newVal1', 'newVal2', 'newVal3']), { attachedDeposit: '100000000000000000000000' });
```
After:
```JS
await ali.call(jsvm, 'call_js_contract', encodeCall(testContract.accountId, 'set_values', { param1: 'newVal1', param2: 'newVal2', param3: 'newVal3' }), { attachedDeposit: '100000000000000000000000' });
```