### PR TITLE
Update README.md Bash Example to Fix for Missing accountId

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ near js deploy --accountId <your-account> --base64File build/<contract-name>.bas
 5. Interact with your contract using NEAR CLI or `near-api-js`. Encode the parameters and call. If the call cause the state increasement, you also need to attach NEAR to cover the storage deposit for the delta.
 
 ```sh
-near js call <account-that-deployed-js-to-jsvm> <method-name> --accountId <account-performing-call> --args <args> --deposit 0.1 --jsvm <jsvm-account>
+near js call <account-that-deployed-js-contract-to-jsvm> <method-name> --accountId <account-performing-call> --args <args> --deposit 0.1 --jsvm <jsvm-account>
 ```
 
 6. If you want to remove the js contract and withdraw the storage deposit, use:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ near js deploy --accountId <your-account> --base64File build/<contract-name>.bas
 5. Interact with your contract using NEAR CLI or `near-api-js`. Encode the parameters and call. If the call cause the state increasement, you also need to attach NEAR to cover the storage deposit for the delta.
 
 ```sh
-near js call <your-account> <method-name> --args <args> --deposit 0.1 --jsvm <jsvm-account>
+near js call <account-that-deployed-js-to-jsvm> <method-name> --accountId <account-performing-call> --args <args> --deposit 0.1 --jsvm <jsvm-account>
 ```
 
 6. If you want to remove the js contract and withdraw the storage deposit, use:


### PR DESCRIPTION
When performing this call without this parameter the following error would be encountered: 

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/10233439/171864946-f301cbce-d490-410c-9e9b-8fa66ddd6a41.png">

After adding this parameter (as shown [in the quickstart docs](https://docs.near.org/docs/develop/contracts/js/enclave-quickstart):

<img width="1247" alt="image" src="https://user-images.githubusercontent.com/10233439/171866402-7aa01416-cc69-48a4-a18a-5062fd169278.png">

A better error! Then finally: 

<img width="930" alt="image" src="https://user-images.githubusercontent.com/10233439/171866475-6c9539f5-301e-4283-8a54-0fd87ddb5d1d.png">
