### PR TITLE
chore: remove unused SDK utility

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,3 @@ export function stringToU8Array(string) {
     }
     return ret
 }
-
-export function encodeCall(contract, method, args) {
-    return Buffer.concat([Buffer.from(contract), Buffer.from([0]), Buffer.from(method), Buffer.from([0]), Buffer.from(JSON.stringify(args))])
-}


### PR DESCRIPTION
closes #92 

Assumed it was connected in some way, doesn't seem like it is