### PR TITLE
Add promise API tests, fix promiseAnd

### DIFF
--- a/lib/api.d.ts
+++ b/lib/api.d.ts
@@ -47,7 +47,7 @@ export declare function accountLockedBalance(): BigInt;
 export declare function valueReturn(value: Bytes): void;
 export declare function promiseCreate(accountId: string, methodName: string, args: Bytes, amount: number | BigInt, gas: number | BigInt): BigInt;
 export declare function promiseThen(promiseIndex: number | BigInt, accountId: string, methodName: string, args: Bytes, amount: number | BigInt, gas: number | BigInt): any;
-export declare function promiseAnd(...promiseIndex: number[] | BigInt[]): any;
+export declare function promiseAnd(...promiseIndex: number[] | BigInt[]): BigInt;
 export declare function promiseBatchCreate(accountId: string): BigInt;
 export declare function promiseBatchThen(promiseIndex: number | BigInt, accountId: string): BigInt;
 export declare function promiseBatchActionCreateAccount(promiseIndex: number | BigInt): void;

--- a/lib/api.js
+++ b/lib/api.js
@@ -211,7 +211,7 @@ export function promiseThen(promiseIndex, accountId, methodName, args, amount, g
     return env.promise_then(promiseIndex, accountId, methodName, args, amount, gas);
 }
 export function promiseAnd(...promiseIndex) {
-    return env.promise(...promiseIndex);
+    return env.promise_and(...promiseIndex);
 }
 export function promiseBatchCreate(accountId) {
     return env.promise_batch_create(accountId);
@@ -257,11 +257,11 @@ export var PromiseResult;
 })(PromiseResult || (PromiseResult = {}));
 export function promiseResult(resultIdx) {
     let status = env.promise_result(resultIdx, 0);
-    if (status === PromiseResult.Successful) {
+    if (status == PromiseResult.Successful) {
         return env.read_register(0);
     }
-    else if (status === PromiseResult.Failed ||
-        status === PromiseResult.NotReady) {
+    else if (status == PromiseResult.Failed ||
+        status == PromiseResult.NotReady) {
         return status;
     }
     else {

--- a/src/api.ts
+++ b/src/api.ts
@@ -298,8 +298,8 @@ export function promiseThen(
   );
 }
 
-export function promiseAnd(...promiseIndex: number[] | BigInt[]) {
-  return env.promise(...promiseIndex);
+export function promiseAnd(...promiseIndex: number[] | BigInt[]): BigInt {
+  return env.promise_and(...promiseIndex);
 }
 
 export function promiseBatchCreate(accountId: string): BigInt {
@@ -413,11 +413,11 @@ export function promiseResult(
   resultIdx: number | BigInt
 ): Bytes | PromiseResult.NotReady | PromiseResult.Failed {
   let status: PromiseResult = env.promise_result(resultIdx, 0);
-  if (status === PromiseResult.Successful) {
+  if (status == PromiseResult.Successful) {
     return env.read_register(0);
   } else if (
-    status === PromiseResult.Failed ||
-    status === PromiseResult.NotReady
+    status == PromiseResult.Failed ||
+    status == PromiseResult.NotReady
   ) {
     return status;
   } else {

--- a/tests/__tests__/test_promise_api.ava.js
+++ b/tests/__tests__/test_promise_api.ava.js
@@ -1,0 +1,120 @@
+import { Worker } from 'near-workspaces';
+import test from 'ava';
+
+
+test.before(async t => {
+    // Init the worker and start a Sandbox server
+    const worker = await Worker.init();
+
+    // Prepare sandbox for tests, create accounts, deploy contracts, etx.
+    const root = worker.rootAccount;
+
+    // Deploy the test contract.
+    const callerContract = await root.createAndDeploy(
+        root.getSubAccount('caller-contract').accountId,
+        'build/promise_api.wasm',
+    );
+
+    const calleeContract = await root.createAndDeploy(
+        root.getSubAccount('callee-contract').accountId,
+        'build/promise_api.wasm',
+    );
+
+    // Test users
+    const ali = await root.createSubAccount('ali');
+
+    // Save state for test runs
+    t.context.worker = worker;
+    t.context.accounts = { root, callerContract, calleeContract, ali };
+});
+
+test.after(async t => {
+    await t.context.worker.tearDown().catch(error => {
+        console.log('Failed to tear down the worker:', error);
+    });
+});
+
+test('promise create', async t => {
+    const { ali, callerContract, calleeContract } = t.context.accounts;
+    // default is 30 TGas, sufficient when the callee contract method is trivial
+    let r = await ali.callRaw(callerContract, 'test_promise_create', '', {gas: '40 Tgas'});
+    t.is(r.result.receipts_outcome[1].outcome.executor_id, calleeContract.accountId);
+    t.deepEqual(Buffer.from(r.result.receipts_outcome[1].outcome.status.SuccessValue, 'base64'), Buffer.from(JSON.stringify({
+        currentAccountId: calleeContract.accountId,
+        signerAccountId: ali.accountId,
+        predecessorAccountId: callerContract.accountId,
+        input: 'abc',
+    })));
+});
+
+test('promise then', async t => {
+    const { ali, callerContract, calleeContract } = t.context.accounts;
+    let r = await ali.callRaw(callerContract, 'test_promise_then', '', {gas: '70 Tgas'});
+    // console.log(JSON.stringify(r, null, 2))
+    // call the callee
+    t.is(r.result.receipts_outcome[1].outcome.executor_id, calleeContract.accountId);
+    t.deepEqual(JSON.parse(Buffer.from(r.result.receipts_outcome[1].outcome.status.SuccessValue, 'base64')), {
+        currentAccountId: calleeContract.accountId,
+        signerAccountId: ali.accountId,
+        predecessorAccountId: callerContract.accountId,
+        input: 'abc',
+    });
+
+    // the callback scheduled by promise_then
+    t.is(r.result.receipts_outcome[3].outcome.executor_id, callerContract.accountId);
+    t.deepEqual(JSON.parse(Buffer.from(r.result.receipts_outcome[3].outcome.status.SuccessValue, 'base64')), {
+        currentAccountId: callerContract.accountId,
+        signerAccountId: ali.accountId,
+        predecessorAccountId: callerContract.accountId,
+        input: 'def',
+        promiseResults: [JSON.stringify({
+            currentAccountId: calleeContract.accountId,
+            signerAccountId: ali.accountId,
+            predecessorAccountId: callerContract.accountId,
+            input: 'abc',
+        })]
+    });
+});
+
+test('promise and', async t => {
+    const { ali, callerContract, calleeContract } = t.context.accounts;
+    let r = await ali.callRaw(callerContract, 'test_promise_and', '', {gas: '150 Tgas'});
+    // console.log(JSON.stringify(r, null, 2))
+    // promise and schedule to call the callee
+    t.is(r.result.receipts_outcome[1].outcome.executor_id, calleeContract.accountId);
+    t.deepEqual(JSON.parse(Buffer.from(r.result.receipts_outcome[1].outcome.status.SuccessValue, 'base64')), {
+        currentAccountId: calleeContract.accountId,
+        signerAccountId: ali.accountId,
+        predecessorAccountId: callerContract.accountId,
+        input: 'abc',
+    });
+
+    // promise and schedule to call the callee, with different args
+    t.is(r.result.receipts_outcome[3].outcome.executor_id, calleeContract.accountId);
+    t.deepEqual(JSON.parse(Buffer.from(r.result.receipts_outcome[3].outcome.status.SuccessValue, 'base64')), {
+        currentAccountId: calleeContract.accountId,
+        signerAccountId: ali.accountId,
+        predecessorAccountId: callerContract.accountId,
+        input: 'def',
+    });
+
+    // the callback scheduled by promise_then on the promise created by promise_and
+    t.is(r.result.receipts_outcome[5].outcome.executor_id, callerContract.accountId);
+    t.deepEqual(JSON.parse(Buffer.from(r.result.receipts_outcome[5].outcome.status.SuccessValue, 'base64')), {
+        currentAccountId: callerContract.accountId,
+        signerAccountId: ali.accountId,
+        predecessorAccountId: callerContract.accountId,
+        input: 'ghi',
+        promiseResults: [JSON.stringify({
+            currentAccountId: calleeContract.accountId,
+            signerAccountId: ali.accountId,
+            predecessorAccountId: callerContract.accountId,
+            input: 'abc',
+        }), JSON.stringify({
+            currentAccountId: calleeContract.accountId,
+            signerAccountId: ali.accountId,
+            predecessorAccountId: callerContract.accountId,
+            input: 'def',
+        })]
+    });
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "type": "module",
     "scripts": {
-        "build": "yarn build:context-api && yarn build:math-api && yarn build:storage-api && yarn build:log-panic-api && yarn build promise-api",
+        "build": "yarn build:context-api && yarn build:math-api && yarn build:storage-api && yarn build:log-panic-api && yarn build:promise-api",
         "build:context-api": "near-sdk build src/context_api.js build/context_api.wasm",
         "build:math-api": "near-sdk build src/math_api.js build/math_api.wasm",
         "build:storage-api": "near-sdk build src/storage_api.js build/storage_api.wasm",

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,17 +5,19 @@
     "main": "index.js",
     "type": "module",
     "scripts": {
-        "build": "yarn build:context-api && yarn build:math-api && yarn build:storage-api && yarn build:log-panic-api",
+        "build": "yarn build:context-api && yarn build:math-api && yarn build:storage-api && yarn build:log-panic-api && yarn build promise-api",
         "build:context-api": "near-sdk build src/context_api.js build/context_api.wasm",
         "build:math-api": "near-sdk build src/math_api.js build/math_api.wasm",
         "build:storage-api": "near-sdk build src/storage_api.js build/storage_api.wasm",
         "build:log-panic-api": "near-sdk build src/log_panic_api.js build/log_panic_api.wasm",
+        "build:promise-api": "near-sdk build src/promise_api.js build/promise_api.wasm",
         "rebuild": "cd .. && yarn build && cd tests && rm -rf node_modules && rm -rf build && yarn && yarn build",
         "test": "ava",
         "test:context-api": "ava __tests__/test_context_api.ava.js",
         "test:math-api": "ava __tests__/test_math_api.ava.js",
         "test:storage-api": "ava __tests__/test_storage_api.ava.js",
-        "test:log-panic-api": "ava __tests__/test_log_panic_api.ava.js"
+        "test:log-panic-api": "ava __tests__/test_log_panic_api.ava.js",
+        "test:promise-api": "ava __tests__/test_promise_api.ava.js"
     },
     "author": "Near Inc <hello@nearprotocol.com>",
     "license": "Apache-2.0",

--- a/tests/src/promise_api.js
+++ b/tests/src/promise_api.js
@@ -1,0 +1,38 @@
+import {near, bytes, call} from 'near-sdk-js'
+
+function arrayN(n) {
+    return [...Array(Number(n)).keys()]
+}
+
+function callingData() {
+    return {
+        currentAccountId: near.currentAccountId(),
+        signerAccountId: near.signerAccountId(),
+        predecessorAccountId: near.predecessorAccountId(),
+        input: near.input(),
+    }
+}
+
+export function cross_contract_callee() {
+    near.valueReturn(bytes(JSON.stringify(callingData())))
+}
+
+export function cross_contract_callback() {
+    near.valueReturn(bytes(JSON.stringify({...callingData(), promiseResults: arrayN(near.promiseResultsCount()).map(i => near.promiseResult(i))})))
+}
+
+export function test_promise_create() {
+    near.promiseCreate('callee-contract.test.near', 'cross_contract_callee', bytes('abc'), 0, 2 * Math.pow(10, 13))
+}
+
+export function test_promise_then() {
+    let promiseId = near.promiseCreate('callee-contract.test.near', 'cross_contract_callee', bytes('abc'), 0, 2 * Math.pow(10, 13))
+    near.promiseThen(promiseId, 'caller-contract.test.near', 'cross_contract_callback', bytes('def'), 0, 2 * Math.pow(10, 13))
+}
+
+export function test_promise_and() {
+    let promiseId = near.promiseCreate('callee-contract.test.near', 'cross_contract_callee', bytes('abc'), 0, 2 * Math.pow(10, 13))
+    let promiseId2 = near.promiseCreate('callee-contract.test.near', 'cross_contract_callee', bytes('def'), 0, 2 * Math.pow(10, 13))
+    let promiseIdAnd = near.promiseAnd(promiseId, promiseId2)
+    near.promiseThen(promiseIdAnd, 'caller-contract.test.near', 'cross_contract_callback', bytes('ghi'), 0, 3 * Math.pow(10, 13))
+}


### PR DESCRIPTION
These tests are intended to cover the most general case: the cross contract call have args, has return values and use the return values from the callback, the callback takes both args and use the value returned from the cross contract call. And the callback also returns value. And also test that in the callee and callback, the context API gives right value.

This doesn't include `promise_batch_*` tests, will be in next PR.