### PR TITLE
add storageByteCost to api and assert to utils

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -33,7 +33,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "lodash-es": "^4.17.21",
-    "near-sdk-js": "file:../near-sdk-js-v0.4.0-2.tgz"
+    "near-sdk-js": "file:../"
   },
   "devDependencies": {
     "ava": "^4.2.0",

--- a/examples/package.json
+++ b/examples/package.json
@@ -33,11 +33,11 @@
   "license": "Apache-2.0",
   "dependencies": {
     "lodash-es": "^4.17.21",
-    "near-sdk-js": "file:../"
+    "near-sdk-js": "file:../near-sdk-js-v0.4.0-2.tgz"
   },
   "devDependencies": {
     "ava": "^4.2.0",
-    "typescript": "^4.7.4",
-    "near-workspaces": "2.0.0"
+    "near-workspaces": "2.0.0",
+    "typescript": "^4.7.4"
   }
 }

--- a/examples/src/fungible-token-lockable.js
+++ b/examples/src/fungible-token-lockable.js
@@ -4,16 +4,9 @@ import {
     call,
     view,
     near,
-    LookupMap
+    LookupMap,
+    assert,
 } from 'near-sdk-js'
-
-function assert(b, str) {
-    if (b) {
-        return
-    } else {
-        throw Error("assertion failed: " + str)
-    }
-}
 
 class Account {
     constructor(balance, allowances, lockedBalances) {

--- a/examples/src/fungible-token.js
+++ b/examples/src/fungible-token.js
@@ -4,16 +4,9 @@ import {
     call,
     view,
     near,
-    LookupMap
+    LookupMap,
+    assert
 } from 'near-sdk-js'
-
-function assert(b, str) {
-    if (b) {
-        return
-    } else {
-        throw Error("assertion failed: " + str)
-    }
-}
 
 @NearBindgen
 class FungibleToken extends NearContract {

--- a/examples/src/non-fungible-token-receiver.js
+++ b/examples/src/non-fungible-token-receiver.js
@@ -1,12 +1,4 @@
-import { NearContract, NearBindgen, call, near } from 'near-sdk-js'
-
-function assert(b, str) {
-    if (b) {
-        return
-    } else {
-        throw Error("assertion failed: " + str)
-    }
-}
+import { NearContract, NearBindgen, call, near, assert } from 'near-sdk-js'
 
 @NearBindgen
 class NftContract extends NearContract {

--- a/examples/src/non-fungible-token.js
+++ b/examples/src/non-fungible-token.js
@@ -1,12 +1,4 @@
-import { NearContract, NearBindgen, call, view, near, LookupMap, bytes } from 'near-sdk-js'
-
-function assert(b, str) {
-    if (b) {
-        return
-    } else {
-        throw Error("assertion failed: " + str)
-    }
-}
+import { NearContract, NearBindgen, call, view, near, LookupMap, bytes, assert } from 'near-sdk-js'
 
 class Token {
     constructor(token_id, owner_id) {

--- a/jsvm/examples/src/fungible-token-lockable.js
+++ b/jsvm/examples/src/fungible-token-lockable.js
@@ -4,16 +4,9 @@ import {
     call,
     view,
     near,
-    LookupMap
+    LookupMap,
+    assert
 } from 'near-sdk-js'
-
-function assert(b, str) {
-    if (b) {
-        return
-    } else {
-        throw Error("assertion failed: " + str)
-    }
-}
 
 class Account {
     constructor(balance, allowances, lockedBalances) {

--- a/jsvm/examples/src/fungible-token.js
+++ b/jsvm/examples/src/fungible-token.js
@@ -4,16 +4,9 @@ import {
     call,
     view,
     near,
-    LookupMap
+    LookupMap,
+    assert
 } from 'near-sdk-js'
-
-function assert(b, str) {
-    if (b) {
-        return
-    } else {
-        throw Error("assertion failed: " + str)
-    }
-}
 
 @NearBindgen
 class FungibleToken extends NearContract {

--- a/jsvm/examples/src/non-fungible-token.js
+++ b/jsvm/examples/src/non-fungible-token.js
@@ -1,12 +1,4 @@
-import { NearContract, NearBindgen, call, view, near, LookupMap } from 'near-sdk-js'
-
-function assert(b, str) {
-    if (b) {
-        return
-    } else {
-        throw Error("assertion failed: " + str)
-    }
-}
+import { NearContract, NearBindgen, call, view, near, LookupMap, assert } from 'near-sdk-js'
 
 class Token {
     constructor(token_id, owner_id) {

--- a/jsvm/examples/src/test-token-receiver.js
+++ b/jsvm/examples/src/test-token-receiver.js
@@ -1,12 +1,4 @@
-import { NearContract, NearBindgen, call, near } from 'near-sdk-js'
-
-function assert(b, str) {
-    if (b) {
-        return
-    } else {
-        throw Error("assertion failed: " + str)
-    }
-}
+import { NearContract, NearBindgen, call, near, assert } from 'near-sdk-js'
 
 @NearBindgen
 class NftContract extends NearContract {

--- a/lib/api.d.ts
+++ b/lib/api.d.ts
@@ -69,3 +69,4 @@ export declare function promiseResult(resultIdx: number | BigInt): Bytes | Promi
 export declare function promiseReturn(promiseIdx: number | BigInt): void;
 export declare function storageWrite(key: Bytes, value: Bytes): boolean;
 export declare function storageRemove(key: Bytes): boolean;
+export declare function storage_byte_cost(): BigInt;

--- a/lib/api.js
+++ b/lib/api.js
@@ -289,3 +289,6 @@ export function storageRemove(key) {
     }
     return false;
 }
+export function storage_byte_cost() {
+    return 10000000000000000000n;
+}

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,4 +3,5 @@ import { NearContract } from "./near-contract";
 import * as near from "./api";
 import { LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet } from "./collections";
 import { bytes, Bytes } from "./utils";
-export { call, view, NearBindgen, NearContract, near, LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet, bytes, Bytes, };
+import * as utils from "./utils";
+export { call, view, NearBindgen, NearContract, near, LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet, bytes, Bytes, utils, };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,6 +2,5 @@ import { call, view, NearBindgen } from "./near-bindgen";
 import { NearContract } from "./near-contract";
 import * as near from "./api";
 import { LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet } from "./collections";
-import { bytes, Bytes } from "./utils";
-import * as utils from "./utils";
-export { call, view, NearBindgen, NearContract, near, LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet, bytes, Bytes, utils, };
+import { bytes, Bytes, assert } from "./utils";
+export { call, view, NearBindgen, NearContract, near, LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet, bytes, Bytes, assert, };

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,5 @@ import { call, view, NearBindgen } from "./near-bindgen";
 import { NearContract } from "./near-contract";
 import * as near from "./api";
 import { LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet, } from "./collections";
-import { bytes } from "./utils";
-import * as utils from "./utils";
-export { call, view, NearBindgen, NearContract, near, LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet, bytes, utils, };
+import { bytes, assert } from "./utils";
+export { call, view, NearBindgen, NearContract, near, LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet, bytes, assert, };

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,4 +3,5 @@ import { NearContract } from "./near-contract";
 import * as near from "./api";
 import { LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet, } from "./collections";
 import { bytes } from "./utils";
-export { call, view, NearBindgen, NearContract, near, LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet, bytes, };
+import * as utils from "./utils";
+export { call, view, NearBindgen, NearContract, near, LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet, bytes, utils, };

--- a/lib/utils.d.ts
+++ b/lib/utils.d.ts
@@ -2,5 +2,4 @@ export declare type Bytes = string;
 export declare function u8ArrayToBytes(array: Uint8Array): string;
 export declare function bytesToU8Array(bytes: Bytes): Uint8Array;
 export declare function bytes(strOrU8Array: string | Uint8Array): Bytes;
-export declare function storage_byte_cost(): BigInt;
 export declare function assert(b: boolean, str: string): void;

--- a/lib/utils.d.ts
+++ b/lib/utils.d.ts
@@ -2,3 +2,5 @@ export declare type Bytes = string;
 export declare function u8ArrayToBytes(array: Uint8Array): string;
 export declare function bytesToU8Array(bytes: Bytes): Uint8Array;
 export declare function bytes(strOrU8Array: string | Uint8Array): Bytes;
+export declare function storage_byte_cost(): BigInt;
+export declare function assert(b: boolean, str: string): void;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,3 +31,14 @@ function checkStringIsBytes(str) {
     }
     return str;
 }
+export function storage_byte_cost() {
+    return 10000000000000000000n;
+}
+export function assert(b, str) {
+    if (b) {
+        return;
+    }
+    else {
+        throw Error("assertion failed: " + str);
+    }
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,9 +31,6 @@ function checkStringIsBytes(str) {
     }
     return str;
 }
-export function storage_byte_cost() {
-    return 10000000000000000000n;
-}
 export function assert(b, str) {
     if (b) {
         return;

--- a/src/api.ts
+++ b/src/api.ts
@@ -448,3 +448,7 @@ export function storageRemove(key: Bytes): boolean {
   }
   return false;
 }
+
+export function storage_byte_cost(): BigInt {
+  return 10_000_000_000_000_000_000n;
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -449,6 +449,6 @@ export function storageRemove(key: Bytes): boolean {
   return false;
 }
 
-export function storage_byte_cost(): BigInt {
+export function storageByteCost(): BigInt {
   return 10_000_000_000_000_000_000n;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from "./collections";
 
 import { bytes, Bytes } from "./utils";
+import * as utils from "./utils";
 
 export {
   call,
@@ -26,4 +27,5 @@ export {
   UnorderedSet,
   bytes,
   Bytes,
+  utils,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,7 @@ import {
   UnorderedSet,
 } from "./collections";
 
-import { bytes, Bytes } from "./utils";
-import * as utils from "./utils";
+import { bytes, Bytes, assert } from "./utils";
 
 export {
   call,
@@ -27,5 +26,5 @@ export {
   UnorderedSet,
   bytes,
   Bytes,
-  utils,
+  assert,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,10 +41,6 @@ function checkStringIsBytes(str: string) {
   return str;
 }
 
-export function storage_byte_cost(): BigInt {
-  return 10_000_000_000_000_000_000n;
-}
-
 export function assert(b: boolean, str: string) {
   if (b) {
       return

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,3 +40,15 @@ function checkStringIsBytes(str: string) {
   }
   return str;
 }
+
+export function storage_byte_cost(): BigInt {
+  return 10_000_000_000_000_000_000n;
+}
+
+export function assert(b: boolean, str: string) {
+  if (b) {
+      return
+  } else {
+      throw Error("assertion failed: " + str)
+  }
+}


### PR DESCRIPTION
storageByteCost is useful in many storage cost related contracts. Copied from rust sdk. assert is commonly used in some of examples. Deserve as part of api.