### PR TITLE
fix near-sdk-js cli when used as yarn link

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -13,7 +13,7 @@ import { rollup } from 'rollup';
 
 import { executeCommand } from './utils.js';
 
-const PROJECT_DIR = `../../../`;
+const PROJECT_DIR = process.cwd();
 const NEAR_SDK_JS = 'node_modules/near-sdk-js';
 const TSC = 'node_modules/.bin/tsc';
 const QJSC_DIR = `${NEAR_SDK_JS}/cli/deps/quickjs`;


### PR DESCRIPTION
Simplify developing examples and tests in repo. Just `yarn link` in project root and `yarn link near-sdk-js` in `examples/` and in `tests/` once. Further changes from sdk-js will be automatically reflected in examples and tests. Also fixed the circular dependency problem #146 :
```
tests (fix-link) ls -l node_modules/near-sdk-js
lrwxrwxrwx 1 bo bo 41 Jul 29 11:58 node_modules/near-sdk-js -> ../../../../.config/yarn/link/near-sdk-js
```