### PR TITLE
fix TypeScript import without .ts by config rollup

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -89,7 +89,9 @@ async function createJsFileWithRullup(sourceFileWithPath, rollupTarget) {
     const bundle = await rollup({
         input: sourceFileWithPath,
         plugins: [
-            nodeResolve(),
+            nodeResolve({
+                extensions: ['.js', '.ts']
+            }),
             sourcemaps(),
             // commonjs(),
             babel({ babelHelpers: 'bundled', extensions: ['.ts', '.js', '.jsx', '.es6', '.es', '.mjs'] })

--- a/examples/__tests__/test-counter.ava.js
+++ b/examples/__tests__/test-counter.ava.js
@@ -59,7 +59,9 @@ test('Decrease works', async t => {
     let result = await counter.view('getCount', {});
     t.is(result, -1);
 
-    await bob.call(counter, 'decrease', { n: 4 });
+    let dec = await bob.callRaw(counter, 'decrease', { n: 4 });
+    // ensure imported log does work, not silent failure
+    t.is(dec.result.receipts_outcome[0].outcome.logs[0], "Counter decreased to -5")
     result = await counter.view('getCount', {});
     t.is(result, -5);
 });

--- a/examples/src/counter.ts
+++ b/examples/src/counter.ts
@@ -1,5 +1,6 @@
 import { NearContract, NearBindgen, near, call, view } from 'near-sdk-js'
 import { isUndefined } from 'lodash-es'
+import { log } from './log'
 
 @NearBindgen
 class Counter extends NearContract {
@@ -25,7 +26,8 @@ class Counter extends NearContract {
         } else {
             this.count -= n
         }
-        near.log(`Counter decreased to ${this.count}`)
+        // this is to illustrate import a local ts module
+        log(`Counter decreased to ${this.count}`)
     }
 
     @view

--- a/examples/src/log.ts
+++ b/examples/src/log.ts
@@ -1,0 +1,5 @@
+import {near} from 'near-sdk-js'
+
+export function log(msg: any) {
+    near.log(msg)
+}


### PR DESCRIPTION
The root problem was: tsc will reject `import ./foo.ts`, only accept `import ./foo`, but rollup was only accepting `import ./foo.ts`. Serhii pointed out tsc cannot support with `.ts` import:  https://github.com/microsoft/TypeScript/issues/37582. So the other way is to configure rollup to accept without `.ts`, which is this PR.