### PR TITLE
modify superserial to output bytes for unicode string to store in trie

### DIFF
--- a/tests/__tests__/lookup-map.ava.js
+++ b/tests/__tests__/lookup-map.ava.js
@@ -120,3 +120,11 @@ test('LookupMap set get object', async t => {
     )
     
 })
+
+test('LookupMap set get unicode string', async t => {
+    const { ali, lookupMapContract } = t.context.accounts;
+    t.is(
+        await ali.call(lookupMapContract, 'store_and_get_utf16_string', {}),
+        2 // two utf-16 character
+    );
+});

--- a/tests/src/lookup-map.js
+++ b/tests/src/lookup-map.js
@@ -59,4 +59,11 @@ class LookupMapTestContract extends NearContract {
         // if and only if house and room is still of class House and Room, this would work:
         return house.describe() + room.describe()
     }
+
+    @call
+    store_and_get_utf16_string() {
+        this.lookupMap.set('wave', '👋')
+        let wave = this.lookupMap.get('wave')
+        return wave.length
+    }
 }


### PR DESCRIPTION
The problem was: superserial serialize object to a JS string (could contain utf16 chars). However, the state could only store bytes. In our modified c runtime, JS string is flatten (into bytes) and stored, so it can be stored. However, when deserialize it back, it deserialize to bytes instead of original string. **There's no way to tell if the original content is the flatten bytes or the utf16 string.**

The repro test in this PR shows above fact. `'👋'.length` is 2 in JavaScript (two utf16 chars), but it is 4 in this repro test. Another serious problem, **if one of two bytes flattened from the utf16 character is `"`, then it would unexpectedly end the string and cause deserialization fail.** 

I had patch node_modules superserial locally and that fix the problem. I still need to figure out the build and release as npm package (superserial is a deno package).  The fix is about checking if it contains utf16 chars, and serialize/deserialize differently for utf16 string and bytes: https://github.com/denostack/superserial/commit/7b73f21047cfd7444fde40ecd16095e1c3ff3648. I'm not very happy with the fix, if you have a good idea that would be great! @volovyk-s 