### PR TITLE
prommiseResult throws an error

### DIFF
--- a/lib/api.d.ts
+++ b/lib/api.d.ts
@@ -1,5 +1,4 @@
 import { Bytes } from "./utils";
-import { PromiseResult } from "./types";
 export declare function log(...params: any[]): void;
 export declare function signerAccountId(): string;
 export declare function signerAccountPk(): Bytes;
@@ -50,7 +49,7 @@ export declare function promiseBatchActionDeleteKey(promiseIndex: number | bigin
 export declare function promiseBatchActionDeleteAccount(promiseIndex: number | bigint, beneficiaryId: string): void;
 export declare function promiseBatchActionFunctionCallWeight(promiseIndex: number | bigint, methodName: string, args: Bytes, amount: number | bigint, gas: number | bigint, weight: number | bigint): void;
 export declare function promiseResultsCount(): bigint;
-export declare function promiseResult(resultIdx: number | bigint): Bytes | PromiseResult.NotReady | PromiseResult.Failed;
+export declare function promiseResult(resultIdx: number | bigint): Bytes;
 export declare function promiseReturn(promiseIdx: number | bigint): void;
 export declare function storageWrite(key: Bytes, value: Bytes): boolean;
 export declare function storageRemove(key: Bytes): boolean;

--- a/lib/api.js
+++ b/lib/api.js
@@ -140,7 +140,6 @@ export function accountLockedBalance() {
     return env.account_locked_balance();
 }
 export function valueReturn(value) {
-    log('valueReturn');
     env.value_return(value);
 }
 export function promiseCreate(accountId, methodName, args, amount, gas) {
@@ -196,16 +195,12 @@ export function promiseResult(resultIdx) {
     if (status == PromiseResult.Successful) {
         return env.read_register(0);
     }
-    else if (status == PromiseResult.Failed ||
-        status == PromiseResult.NotReady) {
-        return status;
-    }
     else {
-        throw Error(`Unexpected return code: ${status}`);
+        throw Error(`Promise result ${status == PromiseResult.Failed ? "Failed" :
+            status == PromiseResult.NotReady ? "NotReady" : status}`);
     }
 }
 export function promiseReturn(promiseIdx) {
-    log('promiseReturn');
     env.promise_return(promiseIdx);
 }
 export function storageWrite(key, value) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -341,19 +341,15 @@ export function promiseResultsCount(): bigint {
   return env.promise_results_count();
 }
 
-export function promiseResult(
-  resultIdx: number | bigint
-): Bytes | PromiseResult.NotReady | PromiseResult.Failed {
+export function promiseResult(resultIdx: number | bigint): Bytes {
   let status: PromiseResult = env.promise_result(resultIdx, 0);
   if (status == PromiseResult.Successful) {
     return env.read_register(0);
-  } else if (
-    status == PromiseResult.Failed ||
-    status == PromiseResult.NotReady
-  ) {
-    return status;
   } else {
-    throw Error(`Unexpected return code: ${status}`);
+    throw Error(
+      `Promise result ${status == PromiseResult.Failed ? "Failed" :
+        status == PromiseResult.NotReady ? "NotReady" : status}`
+    );
   }
 }
 


### PR DESCRIPTION
We should not mimic the Rust design here. Throwing an error is the standard behavior for JS.
The same goes for the return type. I do not want to add {error, result} because it would be the only place in the whole API where we use such a design.