### PR TITLE
always kill sandbox process

### DIFF
--- a/examples/__tests__/test-clean-state.ava.js
+++ b/examples/__tests__/test-clean-state.ava.js
@@ -19,7 +19,7 @@ test.beforeEach(async t => {
     };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed tear down the worker:', error);
     });

--- a/examples/__tests__/test-counter.ava.js
+++ b/examples/__tests__/test-counter.ava.js
@@ -26,7 +26,7 @@ test.beforeEach(async t => {
 });
 
 // If the environment is reused, use test.after to replace test.afterEach
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/examples/__tests__/test-cross-contract-call.ava.js
+++ b/examples/__tests__/test-cross-contract-call.ava.js
@@ -36,7 +36,7 @@ test.beforeEach(async t => {
     };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed tear down the worker:', error);
     });

--- a/examples/__tests__/test-fungible-token-lockable.ava.js
+++ b/examples/__tests__/test-fungible-token-lockable.ava.js
@@ -25,7 +25,7 @@ test.beforeEach(async t => {
     t.context.accounts = { root, lockableFt, ali, bob };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/examples/__tests__/test-fungible-token.ava.js
+++ b/examples/__tests__/test-fungible-token.ava.js
@@ -28,7 +28,7 @@ test.beforeEach(async (t) => {
     t.context.accounts = { root, ft, ali, bob, xcc };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed tear down the worker:', error);
     });

--- a/examples/__tests__/test-non-fungible-token.ava.js
+++ b/examples/__tests__/test-non-fungible-token.ava.js
@@ -38,7 +38,7 @@ test.beforeEach(async t => {
     t.context.accounts = { root, nft, tokenReceiver, tokenId, ali, bob };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed tear down the worker:', error);
     });

--- a/examples/__tests__/test-parking-lot.ava.js
+++ b/examples/__tests__/test-parking-lot.ava.js
@@ -16,7 +16,7 @@ test.beforeEach(async t => {
     t.context.accounts = { root, parkingLot, ali };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/examples/__tests__/test-status-message-collections.ava.js
+++ b/examples/__tests__/test-status-message-collections.ava.js
@@ -24,7 +24,7 @@ test.beforeEach(async t => {
     t.context.accounts = { root, statusMessage, ali, bob, carl };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/examples/__tests__/test-status-message.ava.js
+++ b/examples/__tests__/test-status-message.ava.js
@@ -23,7 +23,7 @@ test.before(async t => {
     t.context.accounts = { root, statusMessage, ali, bob, carl };
 });
 
-test.after(async t => {
+test.after.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/bytes.ava.js
+++ b/tests/__tests__/bytes.ava.js
@@ -20,7 +20,7 @@ test.beforeEach(async t => {
     t.context.accounts = { root, bytesContract, ali };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/decorators/near_bindgen.ava.js
+++ b/tests/__tests__/decorators/near_bindgen.ava.js
@@ -19,7 +19,7 @@ test.beforeEach(async t => {
     };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/decorators/payable.ava.js
+++ b/tests/__tests__/decorators/payable.ava.js
@@ -19,7 +19,7 @@ test.beforeEach(async t => {
 });
 
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/decorators/private.ava.js
+++ b/tests/__tests__/decorators/private.ava.js
@@ -17,7 +17,7 @@ test.beforeEach(async t => {
 });
 
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/function-params.ava.js
+++ b/tests/__tests__/function-params.ava.js
@@ -23,7 +23,7 @@ test.before(async t => {
     t.context.accounts = { root, functionParamsContract, ali, bob, carl };
 });
 
-test.after(async t => {
+test.after.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/lookup-map.ava.js
+++ b/tests/__tests__/lookup-map.ava.js
@@ -23,7 +23,7 @@ test.beforeEach(async t => {
     t.context.accounts = { root, lookupMapContract, ali, bob, carl };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/lookup-set.ava.js
+++ b/tests/__tests__/lookup-set.ava.js
@@ -22,7 +22,7 @@ test.beforeEach(async t => {
     t.context.accounts = { root, lookupSetContract, ali, bob, carl };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/test-public-key.ava.js
+++ b/tests/__tests__/test-public-key.ava.js
@@ -23,7 +23,7 @@ test.before(async t => {
     t.context.accounts = { root, pkContract, ali, bob, carl };
 });
 
-test.after(async t => {
+test.after.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/test_context_api.ava.js
+++ b/tests/__tests__/test_context_api.ava.js
@@ -24,7 +24,7 @@ test.before(async t => {
     t.context.accounts = { root, contextApiContract, ali, bob, carl };
 });
 
-test.after(async t => {
+test.after.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/test_highlevel_promise.ava.js
+++ b/tests/__tests__/test_highlevel_promise.ava.js
@@ -25,7 +25,7 @@ test.before(async t => {
     t.context.accounts = { root, highlevelPromise, ali, bob, calleeContract };
 });
 
-test.after(async t => {
+test.after.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/test_log_panic_api.ava.js
+++ b/tests/__tests__/test_log_panic_api.ava.js
@@ -22,7 +22,7 @@ test.before(async t => {
     t.context.accounts = { root, testContract, ali };
 });
 
-test.after(async t => {
+test.after.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/test_math_api.ava.js
+++ b/tests/__tests__/test_math_api.ava.js
@@ -21,7 +21,7 @@ test.before(async t => {
     t.context.accounts = { root, mathApiContract, ali };
 });
 
-test.after(async t => {
+test.after.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/test_promise_api.ava.js
+++ b/tests/__tests__/test_promise_api.ava.js
@@ -30,7 +30,7 @@ test.before(async t => {
     t.context.accounts = { root, callerContract, calleeContract, ali, bob, caller2Contract };
 });
 
-test.after(async t => {
+test.after.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/test_storage_api.ava.js
+++ b/tests/__tests__/test_storage_api.ava.js
@@ -22,7 +22,7 @@ test.beforeEach(async t => {
     t.context.accounts = { root, storageApiContract, ali };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/typescript.ava.js
+++ b/tests/__tests__/typescript.ava.js
@@ -20,7 +20,7 @@ test.before(async t => {
     t.context.accounts = { root, typescriptContract, ali };
 });
 
-test.after(async t => {
+test.after.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/unordered-map.ava.js
+++ b/tests/__tests__/unordered-map.ava.js
@@ -22,7 +22,7 @@ test.beforeEach(async t => {
     t.context.accounts = { root, unorderedMapContract, ali, bob, carl };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/unordered-set.ava.js
+++ b/tests/__tests__/unordered-set.ava.js
@@ -23,7 +23,7 @@ test.beforeEach(async t => {
     t.context.accounts = { root, unorderedSetContract, ali, bob, carl };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });

--- a/tests/__tests__/vector.ava.js
+++ b/tests/__tests__/vector.ava.js
@@ -23,7 +23,7 @@ test.beforeEach(async t => {
     t.context.accounts = { root, vectorContract, ali, bob, carl };
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
         console.log('Failed to tear down the worker:', error);
     });


### PR DESCRIPTION
Before this change, we were not stopping near-sandbox processes in case the test failed. With time it leads to high memory, CPU, and battery usage.
afterEach.always(...) solves the problem.