### PR TITLE
Add Babel config programmatically

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -98,6 +98,12 @@ async function createJsFileWithRullup(sourceFileWithPath, rollupTarget) {
       babel({
         babelHelpers: "bundled",
         extensions: [".ts", ".js", ".jsx", ".es6", ".es", ".mjs"],
+        presets: ["@babel/preset-typescript"],
+        plugins: [
+          "near-sdk-js/lib/build-tools/include-bytes.js",
+          "near-sdk-js/lib/build-tools/near-bindgen-exporter.js",
+          ["@babel/plugin-proposal-decorators", { version: "legacy" }],
+        ],
       }),
     ],
   });

--- a/examples/babel.config.json
+++ b/examples/babel.config.json
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "near-sdk-js/lib/build-tools/include-bytes",
-    "near-sdk-js/lib/build-tools/near-bindgen-exporter",
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }]
-  ],
-  "presets": ["@babel/preset-typescript"]
-}

--- a/examples/src/nested-collections.ts
+++ b/examples/src/nested-collections.ts
@@ -1,8 +1,7 @@
 import { NearBindgen, near, call, view, UnorderedMap } from "near-sdk-js";
-import { log } from "./log";
 
 @NearBindgen({})
-class Contract {
+export class Contract {
   outerMap: UnorderedMap<UnorderedMap<string>>;
   groups: UnorderedMap<UnorderedMap<UnorderedMap<string>>>;
 

--- a/src/near-bindgen.ts
+++ b/src/near-bindgen.ts
@@ -103,6 +103,7 @@ export function NearBindgen(options: {
   requireInit?: boolean;
   serializer?(value: unknown): string;
   deserializer?(value: string): unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 }): any;
 export function NearBindgen({
   requireInit = false,

--- a/tests/babel.config.json
+++ b/tests/babel.config.json
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "near-sdk-js/lib/build-tools/include-bytes",
-    "near-sdk-js/lib/build-tools/near-bindgen-exporter",
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }]
-  ],
-  "presets": ["@babel/preset-typescript"]
-}


### PR DESCRIPTION
Remove the need to have a separate Babel config file with our custom plugins and presets and encode them programmatically.
Fix some ESLint errors from previous PRs.

This is mentioned in #229.

Note: This Babel config change will still enable the users of the SDK to add their own Babel config file if they need to, those config files will be merged with the config we pass while our config will have precedence.