### PR TITLE
Make PromiseIndex a nominal typing, require explicit construction

### DIFF
--- a/lib/api.d.ts
+++ b/lib/api.d.ts
@@ -122,7 +122,7 @@ export declare function randomSeed(): Bytes;
  * @param amount - The amount of NEAR attached to the call.
  * @param gas - The amount of Gas attached to the call.
  */
-export declare function promiseCreate(accountId: Bytes, methodName: Bytes, args: Bytes, amount: NearAmount, gas: NearAmount): bigint;
+export declare function promiseCreate(accountId: Bytes, methodName: Bytes, args: Bytes, amount: NearAmount, gas: NearAmount): PromiseIndex;
 /**
  * Attach a callback NEAR promise to be executed after a provided promise.
  *
@@ -133,26 +133,26 @@ export declare function promiseCreate(accountId: Bytes, methodName: Bytes, args:
  * @param amount - The amount of NEAR to attach to the call.
  * @param gas - The amount of Gas to attach to the call.
  */
-export declare function promiseThen(promiseIndex: PromiseIndex, accountId: Bytes, methodName: Bytes, args: Bytes, amount: NearAmount, gas: NearAmount): bigint;
+export declare function promiseThen(promiseIndex: PromiseIndex, accountId: Bytes, methodName: Bytes, args: Bytes, amount: NearAmount, gas: NearAmount): PromiseIndex;
 /**
  * Join an arbitrary array of NEAR promises.
  *
  * @param promiseIndexes - An arbitrary array of NEAR promise indexes to join.
  */
-export declare function promiseAnd(...promiseIndexes: PromiseIndex[]): bigint;
+export declare function promiseAnd(...promiseIndexes: PromiseIndex[]): PromiseIndex;
 /**
  * Create a NEAR promise which will have multiple promise actions inside.
  *
  * @param accountId - The account ID of the target contract.
  */
-export declare function promiseBatchCreate(accountId: Bytes): bigint;
+export declare function promiseBatchCreate(accountId: Bytes): PromiseIndex;
 /**
  * Attach a callback NEAR promise to a batch of NEAR promise actions.
  *
  * @param promiseIndex - The NEAR promise index of the batch.
  * @param accountId - The account ID of the target contract.
  */
-export declare function promiseBatchThen(promiseIndex: PromiseIndex, accountId: Bytes): bigint;
+export declare function promiseBatchThen(promiseIndex: PromiseIndex, accountId: Bytes): PromiseIndex;
 /**
  * Attach a create account promise action to the NEAR promise index with the provided promise index.
  *

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1,9 +1,9 @@
 import { AccountId } from "./account_id";
 import { BlockHeight, EpochHeight, Balance, StorageUsage } from "./primitives";
-import { PromiseResult, PromiseError, PromiseIndex, ReceiptIndex, IteratorIndex } from "./vm_types";
+import { PromiseResult, PromiseError, ReceiptIndex, IteratorIndex } from "./vm_types";
 import { Gas, ONE_TERA_GAS } from "./gas";
 import { PublicKey, CurveType, curveTypeFromStr, ParsePublicKeyError, InvalidLengthError, Base58Error, UnknownCurve } from "./public_key";
-export { AccountId, BlockHeight, EpochHeight, Balance, StorageUsage, PromiseResult, PromiseError, PromiseIndex, ReceiptIndex, IteratorIndex, Gas, ONE_TERA_GAS, PublicKey, CurveType, curveTypeFromStr, ParsePublicKeyError, InvalidLengthError, Base58Error, UnknownCurve, };
+export { AccountId, BlockHeight, EpochHeight, Balance, StorageUsage, PromiseResult, PromiseError, ReceiptIndex, IteratorIndex, Gas, ONE_TERA_GAS, PublicKey, CurveType, curveTypeFromStr, ParsePublicKeyError, InvalidLengthError, Base58Error, UnknownCurve, };
 /**
  * The amount of Gas Weight in integers - whole numbers.
  */

--- a/lib/types/vm_types.d.ts
+++ b/lib/types/vm_types.d.ts
@@ -1,8 +1,4 @@
 /**
- * The index for NEAR promises.
- */
-export declare type PromiseIndex = bigint;
-/**
  * The index for NEAR receipts.
  */
 export declare type ReceiptIndex = bigint;

--- a/lib/utils.d.ts
+++ b/lib/utils.d.ts
@@ -4,7 +4,7 @@ import { GetOptions } from "./types/collections";
  */
 export declare type Bytes = string;
 declare enum PromiseIndexBrand {
-    _ = ""
+    _ = -1
 }
 /**
  * A PromiseIndex which represents the ID of a NEAR Promise.

--- a/lib/utils.d.ts
+++ b/lib/utils.d.ts
@@ -3,10 +3,13 @@ import { GetOptions } from "./types/collections";
  * A string containing byte characters. Can be safely used in NEAR calls.
  */
 export declare type Bytes = string;
+declare enum PromiseIndexBrand {
+    _ = ""
+}
 /**
  * A PromiseIndex which represents the ID of a NEAR Promise.
  */
-export declare type PromiseIndex = number | bigint;
+export declare type PromiseIndex = (number | bigint) & PromiseIndexBrand;
 /**
  * A number that specifies the amount of NEAR in yoctoNEAR.
  */
@@ -47,3 +50,4 @@ export declare function deserialize(valueToDeserialize: string): unknown;
  * @param accountId - The Account ID string you want to validate.
  */
 export declare function validateAccountId(accountId: string): boolean;
+export {};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,8 @@
 // make PromiseIndex a nominal typing
 var PromiseIndexBrand;
 (function (PromiseIndexBrand) {
-    PromiseIndexBrand["_"] = "";
+    PromiseIndexBrand[PromiseIndexBrand["_"] = -1] = "_";
 })(PromiseIndexBrand || (PromiseIndexBrand = {}));
-;
 const TYPE_KEY = "typeInfo";
 var TypeBrand;
 (function (TypeBrand) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,9 @@
+// make PromiseIndex a nominal typing
+var PromiseIndexBrand;
+(function (PromiseIndexBrand) {
+    PromiseIndexBrand["_"] = "";
+})(PromiseIndexBrand || (PromiseIndexBrand = {}));
+;
 const TYPE_KEY = "typeInfo";
 var TypeBrand;
 (function (TypeBrand) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -368,7 +368,13 @@ export function promiseCreate(
   amount: NearAmount,
   gas: NearAmount
 ): PromiseIndex {
-  return env.promise_create(accountId, methodName, args, amount, gas) as PromiseIndex;
+  return env.promise_create(
+    accountId,
+    methodName,
+    args,
+    amount,
+    gas
+  ) as PromiseIndex;
 }
 
 /**

--- a/src/api.ts
+++ b/src/api.ts
@@ -74,60 +74,51 @@ interface Env {
     gas: NearAmount
   ): bigint;
   promise_then(
-    promiseIndex: PromiseIndex,
+    promiseIndex: bigint,
     accountId: Bytes,
     methodName: Bytes,
     args: Bytes,
     amount: NearAmount,
     gas: NearAmount
   ): bigint;
-  promise_and(...promiseIndexes: PromiseIndex[]): bigint;
+  promise_and(...promiseIndexes: bigint[]): bigint;
   promise_batch_create(accountId: Bytes): bigint;
-  promise_batch_then(promiseIndex: PromiseIndex, accountId: Bytes): bigint;
-  promise_batch_action_create_account(promiseIndex: PromiseIndex): void;
-  promise_batch_action_deploy_contract(
-    promiseIndex: PromiseIndex,
-    code: Bytes
-  ): void;
+  promise_batch_then(promiseIndex: bigint, accountId: Bytes): bigint;
+  promise_batch_action_create_account(promiseIndex: bigint): void;
+  promise_batch_action_deploy_contract(promiseIndex: bigint, code: Bytes): void;
   promise_batch_action_function_call(
-    promiseIndex: PromiseIndex,
+    promiseIndex: bigint,
     methodName: Bytes,
     args: Bytes,
     amount: NearAmount,
     gas: NearAmount
   ): void;
-  promise_batch_action_transfer(
-    promiseIndex: PromiseIndex,
-    amount: NearAmount
-  ): void;
+  promise_batch_action_transfer(promiseIndex: bigint, amount: NearAmount): void;
   promise_batch_action_stake(
-    promiseIndex: PromiseIndex,
+    promiseIndex: bigint,
     amount: NearAmount,
     publicKey: Bytes
   ): void;
   promise_batch_action_add_key_with_full_access(
-    promiseIndex: PromiseIndex,
+    promiseIndex: bigint,
     publicKey: Bytes,
     nonce: number | bigint
   ): void;
   promise_batch_action_add_key_with_function_call(
-    promiseIndex: PromiseIndex,
+    promiseIndex: bigint,
     publicKey: Bytes,
     nonce: number | bigint,
     allowance: NearAmount,
     receiverId: Bytes,
     methodNames: Bytes
   ): void;
-  promise_batch_action_delete_key(
-    promiseIndex: PromiseIndex,
-    publicKey: Bytes
-  ): void;
+  promise_batch_action_delete_key(promiseIndex: bigint, publicKey: Bytes): void;
   promise_batch_action_delete_account(
-    promiseIndex: PromiseIndex,
+    promiseIndex: bigint,
     beneficiaryId: Bytes
   ): void;
   promise_batch_action_function_call_weight(
-    promiseIndex: PromiseIndex,
+    promiseIndex: bigint,
     methodName: Bytes,
     args: Bytes,
     amount: NearAmount,
@@ -135,8 +126,8 @@ interface Env {
     weight: GasWeight
   ): void;
   promise_results_count(): bigint;
-  promise_result(promiseIndex: PromiseIndex, register: Register): PromiseResult;
-  promise_return(promiseIndex: PromiseIndex): void;
+  promise_result(promiseIndex: bigint, register: Register): PromiseResult;
+  promise_return(promiseIndex: bigint): void;
 }
 
 declare const env: Env;
@@ -374,7 +365,7 @@ export function promiseCreate(
     args,
     amount,
     gas
-  ) as PromiseIndex;
+  ) as unknown as PromiseIndex;
 }
 
 /**
@@ -396,13 +387,13 @@ export function promiseThen(
   gas: NearAmount
 ): PromiseIndex {
   return env.promise_then(
-    promiseIndex,
+    promiseIndex as unknown as bigint,
     accountId,
     methodName,
     args,
     amount,
     gas
-  ) as PromiseIndex;
+  ) as unknown as PromiseIndex;
 }
 
 /**
@@ -411,7 +402,9 @@ export function promiseThen(
  * @param promiseIndexes - An arbitrary array of NEAR promise indexes to join.
  */
 export function promiseAnd(...promiseIndexes: PromiseIndex[]): PromiseIndex {
-  return env.promise_and(...promiseIndexes) as PromiseIndex;
+  return env.promise_and(
+    ...(promiseIndexes as unknown as bigint[])
+  ) as unknown as PromiseIndex;
 }
 
 /**
@@ -420,7 +413,7 @@ export function promiseAnd(...promiseIndexes: PromiseIndex[]): PromiseIndex {
  * @param accountId - The account ID of the target contract.
  */
 export function promiseBatchCreate(accountId: Bytes): PromiseIndex {
-  return env.promise_batch_create(accountId) as PromiseIndex;
+  return env.promise_batch_create(accountId) as unknown as PromiseIndex;
 }
 
 /**
@@ -433,7 +426,10 @@ export function promiseBatchThen(
   promiseIndex: PromiseIndex,
   accountId: Bytes
 ): PromiseIndex {
-  return env.promise_batch_then(promiseIndex, accountId) as PromiseIndex;
+  return env.promise_batch_then(
+    promiseIndex as unknown as bigint,
+    accountId
+  ) as unknown as PromiseIndex;
 }
 
 /**
@@ -444,7 +440,7 @@ export function promiseBatchThen(
 export function promiseBatchActionCreateAccount(
   promiseIndex: PromiseIndex
 ): void {
-  env.promise_batch_action_create_account(promiseIndex);
+  env.promise_batch_action_create_account(promiseIndex as unknown as bigint);
 }
 
 /**
@@ -457,7 +453,10 @@ export function promiseBatchActionDeployContract(
   promiseIndex: PromiseIndex,
   code: Bytes
 ): void {
-  env.promise_batch_action_deploy_contract(promiseIndex, code);
+  env.promise_batch_action_deploy_contract(
+    promiseIndex as unknown as bigint,
+    code
+  );
 }
 
 /**
@@ -477,7 +476,7 @@ export function promiseBatchActionFunctionCall(
   gas: NearAmount
 ): void {
   env.promise_batch_action_function_call(
-    promiseIndex,
+    promiseIndex as unknown as bigint,
     methodName,
     args,
     amount,
@@ -495,7 +494,7 @@ export function promiseBatchActionTransfer(
   promiseIndex: PromiseIndex,
   amount: NearAmount
 ): void {
-  env.promise_batch_action_transfer(promiseIndex, amount);
+  env.promise_batch_action_transfer(promiseIndex as unknown as bigint, amount);
 }
 
 /**
@@ -510,7 +509,11 @@ export function promiseBatchActionStake(
   amount: NearAmount,
   publicKey: Bytes
 ): void {
-  env.promise_batch_action_stake(promiseIndex, amount, publicKey);
+  env.promise_batch_action_stake(
+    promiseIndex as unknown as bigint,
+    amount,
+    publicKey
+  );
 }
 
 /**
@@ -526,7 +529,7 @@ export function promiseBatchActionAddKeyWithFullAccess(
   nonce: number | bigint
 ): void {
   env.promise_batch_action_add_key_with_full_access(
-    promiseIndex,
+    promiseIndex as unknown as bigint,
     publicKey,
     nonce
   );
@@ -551,7 +554,7 @@ export function promiseBatchActionAddKeyWithFunctionCall(
   methodNames: Bytes
 ): void {
   env.promise_batch_action_add_key_with_function_call(
-    promiseIndex,
+    promiseIndex as unknown as bigint,
     publicKey,
     nonce,
     allowance,
@@ -570,7 +573,10 @@ export function promiseBatchActionDeleteKey(
   promiseIndex: PromiseIndex,
   publicKey: Bytes
 ): void {
-  env.promise_batch_action_delete_key(promiseIndex, publicKey);
+  env.promise_batch_action_delete_key(
+    promiseIndex as unknown as bigint,
+    publicKey
+  );
 }
 
 /**
@@ -583,7 +589,10 @@ export function promiseBatchActionDeleteAccount(
   promiseIndex: PromiseIndex,
   beneficiaryId: Bytes
 ): void {
-  env.promise_batch_action_delete_account(promiseIndex, beneficiaryId);
+  env.promise_batch_action_delete_account(
+    promiseIndex as unknown as bigint,
+    beneficiaryId
+  );
 }
 
 /**
@@ -605,7 +614,7 @@ export function promiseBatchActionFunctionCallWeight(
   weight: GasWeight
 ): void {
   env.promise_batch_action_function_call_weight(
-    promiseIndex,
+    promiseIndex as unknown as bigint,
     methodName,
     args,
     amount,
@@ -627,7 +636,7 @@ export function promiseResultsCount(): bigint {
  * @param promiseIndex - The index of the promise to return the result for.
  */
 export function promiseResult(promiseIndex: PromiseIndex): Bytes {
-  const status = env.promise_result(promiseIndex, 0);
+  const status = env.promise_result(promiseIndex as unknown as bigint, 0);
 
   assert(
     Number(status) === PromiseResult.Successful,
@@ -649,7 +658,7 @@ export function promiseResult(promiseIndex: PromiseIndex): Bytes {
  * @param promiseIndex - The index of the promise to execute.
  */
 export function promiseReturn(promiseIndex: PromiseIndex): void {
-  env.promise_return(promiseIndex);
+  env.promise_return(promiseIndex as unknown as bigint);
 }
 
 export function sha256(value: Bytes): Bytes {

--- a/src/api.ts
+++ b/src/api.ts
@@ -367,8 +367,8 @@ export function promiseCreate(
   args: Bytes,
   amount: NearAmount,
   gas: NearAmount
-): bigint {
-  return env.promise_create(accountId, methodName, args, amount, gas);
+): PromiseIndex {
+  return env.promise_create(accountId, methodName, args, amount, gas) as PromiseIndex;
 }
 
 /**
@@ -388,7 +388,7 @@ export function promiseThen(
   args: Bytes,
   amount: NearAmount,
   gas: NearAmount
-): bigint {
+): PromiseIndex {
   return env.promise_then(
     promiseIndex,
     accountId,
@@ -396,7 +396,7 @@ export function promiseThen(
     args,
     amount,
     gas
-  );
+  ) as PromiseIndex;
 }
 
 /**
@@ -404,8 +404,8 @@ export function promiseThen(
  *
  * @param promiseIndexes - An arbitrary array of NEAR promise indexes to join.
  */
-export function promiseAnd(...promiseIndexes: PromiseIndex[]): bigint {
-  return env.promise_and(...promiseIndexes);
+export function promiseAnd(...promiseIndexes: PromiseIndex[]): PromiseIndex {
+  return env.promise_and(...promiseIndexes) as PromiseIndex;
 }
 
 /**
@@ -413,8 +413,8 @@ export function promiseAnd(...promiseIndexes: PromiseIndex[]): bigint {
  *
  * @param accountId - The account ID of the target contract.
  */
-export function promiseBatchCreate(accountId: Bytes): bigint {
-  return env.promise_batch_create(accountId);
+export function promiseBatchCreate(accountId: Bytes): PromiseIndex {
+  return env.promise_batch_create(accountId) as PromiseIndex;
 }
 
 /**
@@ -426,8 +426,8 @@ export function promiseBatchCreate(accountId: Bytes): bigint {
 export function promiseBatchThen(
   promiseIndex: PromiseIndex,
   accountId: Bytes
-): bigint {
-  return env.promise_batch_then(promiseIndex, accountId);
+): PromiseIndex {
+  return env.promise_batch_then(promiseIndex, accountId) as PromiseIndex;
 }
 
 /**

--- a/src/promise.ts
+++ b/src/promise.ts
@@ -255,7 +255,7 @@ class PromiseSingle {
 
   constructRecursively(): PromiseIndex {
     if (this.promiseIndex !== null) {
-      return this.promiseIndex;
+      return this.promiseIndex as PromiseIndex;
     }
 
     const promiseIndex = this.after
@@ -279,7 +279,7 @@ export class PromiseJoint {
 
   constructRecursively(): PromiseIndex {
     if (this.promiseIndex !== null) {
-      return this.promiseIndex;
+      return this.promiseIndex as PromiseIndex;
     }
 
     const result = near.promiseAnd(

--- a/src/promise.ts
+++ b/src/promise.ts
@@ -255,7 +255,7 @@ class PromiseSingle {
 
   constructRecursively(): PromiseIndex {
     if (this.promiseIndex !== null) {
-      return this.promiseIndex as PromiseIndex;
+      return this.promiseIndex;
     }
 
     const promiseIndex = this.after
@@ -279,7 +279,7 @@ export class PromiseJoint {
 
   constructRecursively(): PromiseIndex {
     if (this.promiseIndex !== null) {
-      return this.promiseIndex as PromiseIndex;
+      return this.promiseIndex;
     }
 
     const result = near.promiseAnd(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,6 @@ import { BlockHeight, EpochHeight, Balance, StorageUsage } from "./primitives";
 import {
   PromiseResult,
   PromiseError,
-  PromiseIndex,
   ReceiptIndex,
   IteratorIndex,
 } from "./vm_types";
@@ -26,7 +25,6 @@ export {
   StorageUsage,
   PromiseResult,
   PromiseError,
-  PromiseIndex,
   ReceiptIndex,
   IteratorIndex,
   Gas,

--- a/src/types/vm_types.ts
+++ b/src/types/vm_types.ts
@@ -1,8 +1,4 @@
 /**
- * The index for NEAR promises.
- */
-export type PromiseIndex = bigint;
-/**
  * The index for NEAR receipts.
  */
 export type ReceiptIndex = bigint;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,10 +4,13 @@ import { GetOptions } from "./types/collections";
  * A string containing byte characters. Can be safely used in NEAR calls.
  */
 export type Bytes = string;
+
+// make PromiseIndex a nominal typing
+enum PromiseIndexBrand { _ = "" };
 /**
  * A PromiseIndex which represents the ID of a NEAR Promise.
  */
-export type PromiseIndex = number | bigint;
+export type PromiseIndex = (number | bigint) & PromiseIndexBrand;
 /**
  * A number that specifies the amount of NEAR in yoctoNEAR.
  */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ export type Bytes = string;
 
 // make PromiseIndex a nominal typing
 enum PromiseIndexBrand {
-  _ = "",
+  _ = -1,
 }
 /**
  * A PromiseIndex which represents the ID of a NEAR Promise.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,9 @@ import { GetOptions } from "./types/collections";
 export type Bytes = string;
 
 // make PromiseIndex a nominal typing
-enum PromiseIndexBrand { _ = "" };
+enum PromiseIndexBrand {
+  _ = "",
+}
 /**
  * A PromiseIndex which represents the ID of a NEAR Promise.
  */


### PR DESCRIPTION
Fix #118 . Makes PromiseIndex a nominal type, which is different from bigint or number. User cannot construct such a type, unless force typecast `x as unknown as PromiseIndex`. Since typescript cannot really prevent user force typecast to an exported type, I think it's the closest semantics to "There should be no way to manually construct a promise index, (PromiseIndex) are only constructed by those functions" suggested by @austinabell 