### PR TITLE
TSC error suppression for latest versions

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -58,7 +58,7 @@ export async function buildCom(source, target, { verbose = false }) {
     signale.success(`Generated ${CONTRACT_TARGET} contract successfully!`);
 }
 async function checkTsBuildWithTsc(sourceFileWithPath, verbose = false) {
-    await executeCommand(`${TSC} --noEmit --experimentalDecorators --target es2020 --moduleResolution node ${sourceFileWithPath}`, verbose);
+    await executeCommand(`${TSC} --noEmit --skipLibCheck --experimentalDecorators --target es2020 --moduleResolution node ${sourceFileWithPath}`, verbose);
 }
 // Common build function
 async function createJsFileWithRullup(sourceFileWithPath, rollupTarget, verbose = false) {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -92,7 +92,7 @@ async function checkTsBuildWithTsc(
   verbose = false
 ) {
   await executeCommand(
-    `${TSC} --noEmit --experimentalDecorators --target es2020 --moduleResolution node ${sourceFileWithPath}`,
+    `${TSC} --noEmit --skipLibCheck --experimentalDecorators --target es2020 --moduleResolution node ${sourceFileWithPath}`,
     verbose
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "experimentalDecorators": true,
     "resolveJsonModule": true,
     "allowJs": true,
-    "skipLibCheck": true,
+    "skipLibCheck": true
   },
   "files": [
     "src/index.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "noUnusedLocals": true,
     "experimentalDecorators": true,
     "resolveJsonModule": true,
-    "allowJs": true
+    "allowJs": true,
+    "skipLibCheck": true,
   },
   "files": [
     "src/index.ts",


### PR DESCRIPTION
## Problem summary
Newer versions of TypeScript seem to be throwing compile-time errors deep within the `lib.dom.ts` file, with the error looking something like this:

`"node_modules/typescript/lib/lib.dom.d.ts(14578,11): error TS2430: Interface 'WebGL2RenderingContext' incorrectly extends interface 'WebGL2RenderingContextBase'.\n"`

A quick and dirty fix is to skip library checks, [according to this discussion](https://github.com/moment/moment/issues/4459). That's what is contained in this pull request. 

## Env parameters
My machine, which recorded this issue, is a Macbook Pro (2019), running Node `v16.9.0`, npm `8.19.2` and TypeScript `v4.8.4`. This happened with the latest near app build via `npx create-near-app@latest`.

