### PR TITLE
Update cli.js to avoid error when importing ethers.js

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -3,6 +3,7 @@ import fs from "fs";
 import path, { basename, dirname } from "path";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import sourcemaps from "rollup-plugin-sourcemaps";
+import commonjs from "@rollup/plugin-commonjs";
 import { babel } from "@rollup/plugin-babel";
 import { rollup } from "rollup";
 import { Command } from "commander";
@@ -75,7 +76,9 @@ async function createJsFileWithRullup(sourceFileWithPath, rollupTarget, verbose 
                 extensions: [".js", ".ts"],
             }),
             sourcemaps(),
-            // commonjs(),
+            commonjs({
+                defaultIsModuleExports: true
+            }),
             babel({
                 babelHelpers: "bundled",
                 extensions: [".ts", ".js", ".jsx", ".es6", ".es", ".mjs"],


### PR DESCRIPTION
this add lets you use the package `ethers.js`, pretty important in some contexts

If rollup is configured in this way, you get the error `Error: 'default' is not exported by node_modules/bn.js/lib/bn.js, imported by node_modules/@ethersproject/bignumber/lib.esm/bignumber.js` when you try to do `import {ethers} from "ethers";` in your smart contract