### PR TITLE
[bugfix] display stderr on command failure

### DIFF
--- a/lib/cli/utils.js
+++ b/lib/cli/utils.js
@@ -10,20 +10,26 @@ export async function executeCommand(command, verbose = false) {
     if (verbose) {
         signale.info(`Running command: ${command}`);
     }
+    let stdout, stderr, code = 0;
     try {
-        const { stdout, stderr } = await exec(command);
-        if (stderr && verbose) {
-            signale.error(stderr);
-        }
-        if (verbose) {
-            signale.info(`Command output: ${stdout}`);
-        }
-        return stdout.trim();
+        ({ stdout, stderr } = await exec(command));
     }
     catch (error) {
-        signale.error(error);
+        ({ stdout, stderr, code } = error);
+    }
+    if (code != 0) {
+        signale.error(`Command failed: ${command}`);
+    }
+    if (stderr && verbose) {
+        signale.error(`Command stderr: ${stderr}`);
+    }
+    if (verbose) {
+        signale.info(`Command stdout: ${stdout}`);
+    }
+    if (code != 0) {
         process.exit(1);
     }
+    return stdout.trim();
 }
 export async function download(url, verbose = false) {
     await executeCommand(`curl -LOf ${url}`, verbose);

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -18,22 +18,26 @@ export async function executeCommand(
     signale.info(`Running command: ${command}`);
   }
 
-  try {
-    const { stdout, stderr } = await exec(command);
-
+  let stdout, stderr, code = 0;
+    try {
+        ({ stdout, stderr } = await exec(command));
+    } catch (error) {
+        ({ stdout, stderr, code} = error);
+    }
+    if(code != 0) {
+        signale.error(`Command failed: ${command}`);
+    }
     if (stderr && verbose) {
-      signale.error(stderr);
+        signale.error(`Command stderr: ${stderr}`);
     }
-
     if (verbose) {
-      signale.info(`Command output: ${stdout}`);
+        signale.info(`Command stdout: ${stdout}`);
     }
-
+    if(code != 0){
+        process.exit(1);
+    }
     return stdout.trim();
-  } catch (error) {
-    signale.error(error);
-    process.exit(1);
-  }
+    
 }
 
 export async function download(url: string, verbose = false) {


### PR DESCRIPTION
## Repro
If you run the SDK CLI against a broken Typescript file, nothing useful is outputted:

```
(base) ~/D/C/n/near-sdk-js ❯❯❯ ./lib/cli/cli.js build --verbose ./examples/src/log.ts                                                                                       ✘ 1 
…  awaiting  Building ./examples/src/log.ts contract...
…  awaiting  Typechecking ./examples/src/log.ts with tsc...
[exec] › ℹ  info      Running command: node_modules/.bin/tsc  --skipLibCheck --experimentalDecorators --target es2020 --moduleResolution node ./examples/src/log.ts
[exec] › ✖  error     Error: Command failed: node_modules/.bin/tsc  --skipLibCheck --experimentalDecorators --target es2020 --moduleResolution node ./examples/src/log.ts 

    at ChildProcess.exithandler (node:child_process:398:12)
    at ChildProcess.emit (node:events:527:28)
    at maybeClose (node:internal/child_process:1092:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:302:5)
```

## Root Cause
- The promisified childProcess.exec (invoked [here](https://github.com/near/near-sdk-js/blob/develop/lib/cli/utils.js#L14)) throws an error if the command returns a non-zero code.
- This error contains `stdout` and `stderr` information, but this isn't printed to console in the [`catch` block](https://github.com/near/near-sdk-js/blob/develop/lib/cli/utils.js#L24).

## Fix
This PR changes the CLI behavior to print `stderr` and `stdout` when a command exits with a non-zero exit code. This is useful for debugging and diagnosis.  This is done by unifying the try/catch paths somewhat.