### PR TITLE
Exports refactored

### DIFF
--- a/lib/collections/index.d.ts
+++ b/lib/collections/index.d.ts
@@ -1,6 +1,5 @@
-import { LookupMap } from "./lookup-map";
-import { Vector } from "./vector";
-import { LookupSet } from "./lookup-set";
-import { UnorderedMap } from "./unordered-map";
-import { UnorderedSet } from "./unordered-set";
-export { LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet };
+export * from "./lookup-map";
+export * from "./lookup-set";
+export * from "./unordered-map";
+export * from "./unordered-set";
+export * from "./vector";

--- a/lib/collections/index.js
+++ b/lib/collections/index.js
@@ -1,6 +1,5 @@
-import { LookupMap } from "./lookup-map";
-import { Vector } from "./vector";
-import { LookupSet } from "./lookup-set";
-import { UnorderedMap } from "./unordered-map";
-import { UnorderedSet } from "./unordered-set";
-export { LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet };
+export * from "./lookup-map";
+export * from "./lookup-set";
+export * from "./unordered-map";
+export * from "./unordered-set";
+export * from "./vector";

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,6 +1,6 @@
-export * as near from "./api";
-export * from "./types";
-export * from "./near-bindgen";
 export * from "./collections";
-export * from "./utils";
+export * from "./types";
+export * as near from "./api";
+export * from "./near-bindgen";
 export * from "./promise";
+export * from "./utils";

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
-export * as near from "./api";
-export * from "./types";
-export * from "./near-bindgen";
 export * from "./collections";
-export * from "./utils";
+export * from "./types";
+export * as near from "./api";
+export * from "./near-bindgen";
 export * from "./promise";
+export * from "./utils";

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1,18 +1,5 @@
-import { AccountId } from "./account_id";
-import { BlockHeight, EpochHeight, Balance, StorageUsage } from "./primitives";
-import { PromiseResult, PromiseError, ReceiptIndex, IteratorIndex } from "./vm_types";
-import { Gas, ONE_TERA_GAS } from "./gas";
-import { PublicKey, CurveType, curveTypeFromStr, ParsePublicKeyError, InvalidLengthError, Base58Error, UnknownCurve } from "./public_key";
-export { AccountId, BlockHeight, EpochHeight, Balance, StorageUsage, PromiseResult, PromiseError, ReceiptIndex, IteratorIndex, Gas, ONE_TERA_GAS, PublicKey, CurveType, curveTypeFromStr, ParsePublicKeyError, InvalidLengthError, Base58Error, UnknownCurve, };
-/**
- * The amount of Gas Weight in integers - whole numbers.
- */
-export declare type GasWeight = bigint;
-/**
- * One yoctoNEAR. 10^-24 NEAR.
- */
-export declare const ONE_YOCTO: Balance;
-/**
- * One NEAR. 1 NEAR = 10^24 yoctoNEAR.
- */
-export declare const ONE_NEAR: Balance;
+export * from "./account_id";
+export * from "./gas";
+export * from "./primitives";
+export * from "./public_key";
+export * from "./vm_types";

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -1,12 +1,5 @@
-import { PromiseResult, PromiseError, } from "./vm_types";
-import { ONE_TERA_GAS } from "./gas";
-import { PublicKey, CurveType, curveTypeFromStr, ParsePublicKeyError, InvalidLengthError, Base58Error, UnknownCurve, } from "./public_key";
-export { PromiseResult, PromiseError, ONE_TERA_GAS, PublicKey, CurveType, curveTypeFromStr, ParsePublicKeyError, InvalidLengthError, Base58Error, UnknownCurve, };
-/**
- * One yoctoNEAR. 10^-24 NEAR.
- */
-export const ONE_YOCTO = 1n;
-/**
- * One NEAR. 1 NEAR = 10^24 yoctoNEAR.
- */
-export const ONE_NEAR = 1000000000000000000000000n;
+export * from "./account_id";
+export * from "./gas";
+export * from "./primitives";
+export * from "./public_key";
+export * from "./vm_types";

--- a/lib/types/primitives.d.ts
+++ b/lib/types/primitives.d.ts
@@ -18,3 +18,15 @@ export declare type Balance = bigint;
  * A large integer representing the nonce.
  */
 export declare type Nonce = bigint;
+/**
+ * The amount of Gas Weight in integers - whole numbers.
+ */
+export declare type GasWeight = bigint;
+/**
+ * One yoctoNEAR. 10^-24 NEAR.
+ */
+export declare const ONE_YOCTO: Balance;
+/**
+ * One NEAR. 1 NEAR = 10^24 yoctoNEAR.
+ */
+export declare const ONE_NEAR: Balance;

--- a/lib/types/primitives.js
+++ b/lib/types/primitives.js
@@ -1,1 +1,8 @@
-export {};
+/**
+ * One yoctoNEAR. 10^-24 NEAR.
+ */
+export const ONE_YOCTO = 1n;
+/**
+ * One NEAR. 1 NEAR = 10^24 yoctoNEAR.
+ */
+export const ONE_NEAR = 1000000000000000000000000n;

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -1,7 +1,5 @@
-import { LookupMap } from "./lookup-map";
-import { Vector } from "./vector";
-import { LookupSet } from "./lookup-set";
-import { UnorderedMap } from "./unordered-map";
-import { UnorderedSet } from "./unordered-set";
-
-export { LookupMap, Vector, LookupSet, UnorderedMap, UnorderedSet };
+export * from "./lookup-map";
+export * from "./lookup-set";
+export * from "./unordered-map";
+export * from "./unordered-set";
+export * from "./vector";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-export * as near from "./api";
-export * from "./types";
-export * from "./near-bindgen";
 export * from "./collections";
-export * from "./utils";
+export * from "./types";
+export * as near from "./api";
+export * from "./near-bindgen";
 export * from "./promise";
+export * from "./utils";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,52 +1,5 @@
-import { AccountId } from "./account_id";
-import { BlockHeight, EpochHeight, Balance, StorageUsage } from "./primitives";
-import {
-  PromiseResult,
-  PromiseError,
-  ReceiptIndex,
-  IteratorIndex,
-} from "./vm_types";
-import { Gas, ONE_TERA_GAS } from "./gas";
-import {
-  PublicKey,
-  CurveType,
-  curveTypeFromStr,
-  ParsePublicKeyError,
-  InvalidLengthError,
-  Base58Error,
-  UnknownCurve,
-} from "./public_key";
-
-export {
-  AccountId,
-  BlockHeight,
-  EpochHeight,
-  Balance,
-  StorageUsage,
-  PromiseResult,
-  PromiseError,
-  ReceiptIndex,
-  IteratorIndex,
-  Gas,
-  ONE_TERA_GAS,
-  PublicKey,
-  CurveType,
-  curveTypeFromStr,
-  ParsePublicKeyError,
-  InvalidLengthError,
-  Base58Error,
-  UnknownCurve,
-};
-
-/**
- * The amount of Gas Weight in integers - whole numbers.
- */
-export type GasWeight = bigint;
-/**
- * One yoctoNEAR. 10^-24 NEAR.
- */
-export const ONE_YOCTO: Balance = 1n;
-/**
- * One NEAR. 1 NEAR = 10^24 yoctoNEAR.
- */
-export const ONE_NEAR: Balance = 1_000_000_000_000_000_000_000_000n;
+export * from "./account_id";
+export * from "./gas";
+export * from "./primitives";
+export * from "./public_key";
+export * from "./vm_types";

--- a/src/types/primitives.ts
+++ b/src/types/primitives.ts
@@ -21,13 +21,12 @@ export type Nonce = bigint;
 /**
  * The amount of Gas Weight in integers - whole numbers.
  */
- export type GasWeight = bigint;
- /**
-  * One yoctoNEAR. 10^-24 NEAR.
-  */
- export const ONE_YOCTO: Balance = 1n;
- /**
-  * One NEAR. 1 NEAR = 10^24 yoctoNEAR.
-  */
- export const ONE_NEAR: Balance = 1_000_000_000_000_000_000_000_000n;
- 
+export type GasWeight = bigint;
+/**
+ * One yoctoNEAR. 10^-24 NEAR.
+ */
+export const ONE_YOCTO: Balance = 1n;
+/**
+ * One NEAR. 1 NEAR = 10^24 yoctoNEAR.
+ */
+export const ONE_NEAR: Balance = 1_000_000_000_000_000_000_000_000n;

--- a/src/types/primitives.ts
+++ b/src/types/primitives.ts
@@ -18,3 +18,16 @@ export type Balance = bigint;
  * A large integer representing the nonce.
  */
 export type Nonce = bigint;
+/**
+ * The amount of Gas Weight in integers - whole numbers.
+ */
+ export type GasWeight = bigint;
+ /**
+  * One yoctoNEAR. 10^-24 NEAR.
+  */
+ export const ONE_YOCTO: Balance = 1n;
+ /**
+  * One NEAR. 1 NEAR = 10^24 yoctoNEAR.
+  */
+ export const ONE_NEAR: Balance = 1_000_000_000_000_000_000_000_000n;
+ 


### PR DESCRIPTION
Let's follow this standard for exported functions and primitives. The file where it's defined is the only source of truth to check if it's exported. In case we need internal utils or something similar, they should be named accordingly and not be exported at all. 