### PR TITLE
Fix build script when there is space in project path

### DIFF
--- a/packages/near-sdk-js/lib/cli/cli.js
+++ b/packages/near-sdk-js/lib/cli/cli.js
@@ -228,5 +228,5 @@ async function createWasmContract(qjscTarget, contractTarget, verbose = false) {
 }
 async function wasiStubContract(contractTarget, verbose = false) {
     const WASI_STUB = `${NEAR_SDK_JS}/lib/cli/deps/binaryen/wasi-stub/run.sh`;
-    await executeCommand(`${WASI_STUB} ${contractTarget} >/dev/null`, verbose);
+    await executeCommand(`${WASI_STUB} ${contractTarget}`, verbose);
 }

--- a/packages/near-sdk-js/lib/cli/post-install.js
+++ b/packages/near-sdk-js/lib/cli/post-install.js
@@ -24,7 +24,7 @@ if (!SUPPORTED_ARCH.includes(ARCH)) {
     process.exit(1);
 }
 signale.await("Installing wasi-stub...");
-const BINARYEN_VERSION = `0.1.10`;
+const BINARYEN_VERSION = `0.1.15`;
 const BINARYEN_VERSION_TAG = `v${BINARYEN_VERSION}`;
 const BINARYEN_SYSTEM_NAME = PLATFORM === "linux"
     ? "Linux"

--- a/packages/near-sdk-js/src/cli/cli.ts
+++ b/packages/near-sdk-js/src/cli/cli.ts
@@ -385,5 +385,5 @@ async function createWasmContract(
 
 async function wasiStubContract(contractTarget: string, verbose = false) {
   const WASI_STUB = `${NEAR_SDK_JS}/lib/cli/deps/binaryen/wasi-stub/run.sh`;
-  await executeCommand(`${WASI_STUB} ${contractTarget} >/dev/null`, verbose);
+  await executeCommand(`${WASI_STUB} ${contractTarget}`, verbose);
 }

--- a/packages/near-sdk-js/src/cli/post-install.ts
+++ b/packages/near-sdk-js/src/cli/post-install.ts
@@ -33,7 +33,7 @@ if (!SUPPORTED_ARCH.includes(ARCH)) {
 
 signale.await("Installing wasi-stub...");
 
-const BINARYEN_VERSION = `0.1.10`;
+const BINARYEN_VERSION = `0.1.15`;
 const BINARYEN_VERSION_TAG = `v${BINARYEN_VERSION}`;
 
 const BINARYEN_SYSTEM_NAME =


### PR DESCRIPTION
Fix #248 , main problem is fixed in near/binaryen wasi-stub wrapper script, where it didn't handle space in path