### PR TITLE
Remove alpha warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,6 @@
 
 A JavaScript library for writing NEAR smart contracts.
 
-> **Warning**
->
-> This SDK is currently in **[`Alpha`](https://github.com/near/near-sdk-js/releases/)**.
->
-> The JavaScript runtime has not been fully audited. For creating smart contracts that hold value please use [`near-sdk-rs`](https://github.com/near/near-sdk-rs).
->
-> Help contribute!
->
-> - [Report issues you encounter](https://github.com/near/near-sdk-js/issues) 🐞
-> - [Provide suggestions or feedback](https://github.com/near/near-sdk-js/discussions) 💡
-> - [Show us what you've built!](https://github.com/near/near-sdk-js/discussions/categories/show-and-tell) 💪
-
 ## Prerequisites
 
 - node >=14 <16.6.0 || >16.6.0


### PR DESCRIPTION
Since we have done testing regarding arithmetic correctness in https://github.com/near/libbf-test, in the same test suite for the C++'s boost.multiprecision library. We consider the JavaScript runtime is reasonably secure for DApps and even financial DApps. The project is therefore moving forward from the alpha stage.

This doesn't mean a formal audit or comprehensive testing of entire quickjs runtime, but it is an due diligence effort to ensure the most critical part: value-related calculation is well-tested. We will continue doing ourselves, seeking professional audit team and supporting community builders to increase the reliability and security of near-sdk-js.

The contributing parts at beginning of the doc is duplicate to the `## Contributing` section later, so it's also removed.

This PR closes #312.
