### PR TITLE
Error and stop build a contract that has method name confliction

### DIFF
--- a/packages/near-sdk-js/lib/cli/cli.js
+++ b/packages/near-sdk-js/lib/cli/cli.js
@@ -206,6 +206,10 @@ async function createMethodsHeaderFile(rollupTarget, verbose = false) {
     }
     const mod = await import(`${PROJECT_DIR}/${rollupTarget}`);
     const exportNames = Object.keys(mod);
+    if (exportNames.includes('panic')) {
+        signal.error("'panic' is a reserved word, please use another name for contract method");
+        process.exit(1);
+    }
     const methods = exportNames.reduce((result, key) => `${result}DEFINE_NEAR_METHOD(${key})\n`, "");
     fs.writeFileSync(`${buildPath}/methods.h`, methods);
 }

--- a/packages/near-sdk-js/lib/cli/utils.js
+++ b/packages/near-sdk-js/lib/cli/utils.js
@@ -19,6 +19,10 @@ export async function executeCommand(command, verbose = false) {
     }
     if (code != 0) {
         signale.error(`Command failed: ${command}`);
+        const failDueToNameConflict = stderr.match(/conflicting types for '([a-zA-Z0-9_]+)'/);
+        if (failDueToNameConflict.length > 1) {
+            signale.error(`'${failDueToNameConflict[1]}' is a reserved word, please use another name for contract method"`);
+        }
     }
     if (stderr && verbose) {
         signale.error(`Command stderr: ${stderr}`);

--- a/packages/near-sdk-js/src/cli/cli.ts
+++ b/packages/near-sdk-js/src/cli/cli.ts
@@ -342,6 +342,12 @@ async function createMethodsHeaderFile(rollupTarget: string, verbose = false) {
 
   const mod = await import(`${PROJECT_DIR}/${rollupTarget}`);
   const exportNames = Object.keys(mod);
+  if (exportNames.includes('panic')) {
+    signal.error(
+      "'panic' is a reserved word, please use another name for contract method"
+    );
+    process.exit(1);
+  }
   const methods = exportNames.reduce(
     (result, key) => `${result}DEFINE_NEAR_METHOD(${key})\n`,
     ""

--- a/packages/near-sdk-js/src/cli/utils.ts
+++ b/packages/near-sdk-js/src/cli/utils.ts
@@ -28,6 +28,11 @@ export async function executeCommand(
   }
   if (code != 0) {
     signale.error(`Command failed: ${command}`);
+
+    const failDueToNameConflict = stderr.match(/conflicting types for '([a-zA-Z0-9_]+)'/);
+    if (failDueToNameConflict.length > 1) {
+      signale.error(`'${failDueToNameConflict[1]}' is a reserved word, please use another name for contract method"`);
+    }
   }
   if (stderr && verbose) {
     signale.error(`Command stderr: ${stderr}`);


### PR DESCRIPTION
This PR is to address #121.

The near-sdk-js builds a contract by generate a C file and turns each contract method to a C function, then compile this C file into a wasm file. Therefore, it's possible the contract method name conflicts with the C function name in `builder.c`. 

Because a contract method name `foo` will generate a `void foo(void)` in the C file, there're totally 4 possible cases of different result will happen. Those are a contract method name `foo` becomes the same as: 
1. a `void foo(void)` in `builder.c` or it's include
2. an `extern void foo(void)` in `builder.c`or it's include
3. a `foo` function with other signature in `builder.c` or it's include. E.g.: `strcpy`
4. an `extern foo` function with other signature. E.g.: `storage_read`.

Case 1. doesn't exist as we checked `builder.c` and it's include. Case 2. only has one function `panic`. If user attempts to define a `panic` contract method, it will cause `env.panic()` call that method instead, which causes misleading result. In this PR this becomes an error. In case 3 and 4, the `C -> WASM` step C compiler gives error because breaks the C signature. In this PR, it collects the error message, transform it into a user friendly one and inform user to avoid using `foo` and ends the build.

All cases are tested with the CLI in this PR. It reports errors like this:
- case 2:
<img width="609" alt="image" src="https://user-images.githubusercontent.com/13259400/220854342-6e86ec6d-7b74-450c-8a47-c802bb92bb01.png">
- case 3&4:
<img width="1285" alt="image" src="https://user-images.githubusercontent.com/13259400/220854273-8d353fb5-b120-4362-96db-4c890536597c.png">

