### PR TITLE
Fix the returned type of the includeBytes function from string to Uin…

### DIFF
--- a/packages/near-sdk-js/lib/near-bindgen.d.ts
+++ b/packages/near-sdk-js/lib/near-bindgen.d.ts
@@ -69,6 +69,6 @@ declare module "./" {
      *
      * @param pathToWasm - The path to the WASM file to read code from.
      */
-    function includeBytes(pathToWasm: string): string;
+    function includeBytes(pathToWasm: string): Uint8Array;
 }
 export {};

--- a/packages/near-sdk-js/src/near-bindgen.ts
+++ b/packages/near-sdk-js/src/near-bindgen.ts
@@ -234,5 +234,5 @@ declare module "./" {
    *
    * @param pathToWasm - The path to the WASM file to read code from.
    */
-  export function includeBytes(pathToWasm: string): string;
+  export function includeBytes(pathToWasm: string): Uint8Array;
 }


### PR DESCRIPTION
…t8Array

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript SDK here: https://github.com/near/near-sdk-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-sdk-js/blob/master/CONTRIBUTING.md).
- [ ] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
