### PR TITLE
Implement improvements as suggested in the last report

### DIFF
--- a/packages/near-sdk-js/builder/builder.c
+++ b/packages/near-sdk-js/builder/builder.c
@@ -10,7 +10,6 @@ static JSContext *JS_NewCustomContext(JSRuntime *rt)
     return NULL;
   JS_AddIntrinsicBaseObjects(ctx);
   JS_AddIntrinsicDate(ctx);
-  JS_AddIntrinsicEval(ctx);
   JS_AddIntrinsicStringNormalize(ctx);
   JS_AddIntrinsicRegExp(ctx);
   JS_AddIntrinsicJSON(ctx);
@@ -22,8 +21,15 @@ static JSContext *JS_NewCustomContext(JSRuntime *rt)
   return ctx;
 }
 
+extern void _initialize(void);
+
 #define DEFINE_NEAR_METHOD(name) \
   void name () __attribute__((export_name(#name))) {\
+    static volatile int initialized = 0;\
+    if (initialized == 0) {\
+      _initialize();\
+      initialized = 1;\
+    }\
     JSRuntime *rt;\
     JSContext *ctx;\
     JSValue mod_obj, fun_obj, result, error, error_message, error_stack;\
@@ -1185,7 +1191,5 @@ static void js_add_near_host_functions(JSContext* ctx) {
 
 JSValue JS_Call(JSContext *ctx, JSValueConst func_obj, JSValueConst this_obj,
                 int argc, JSValueConst *argv);
-
-void _start() {}
 
 #include "methods.h"

--- a/packages/near-sdk-js/lib/cli/post-install.js
+++ b/packages/near-sdk-js/lib/cli/post-install.js
@@ -23,22 +23,6 @@ if (!SUPPORTED_ARCH.includes(ARCH)) {
     console.error(`Architecture ${ARCH} is not supported at the moment`);
     process.exit(1);
 }
-signale.await("Installing wasi-stub...");
-const BINARYEN_VERSION = `0.1.15`;
-const BINARYEN_VERSION_TAG = `v${BINARYEN_VERSION}`;
-const BINARYEN_SYSTEM_NAME = PLATFORM === "linux"
-    ? "Linux"
-    : PLATFORM === "darwin"
-        ? "macOS"
-        : PLATFORM === "win32"
-            ? "windows"
-            : "other";
-const BINARYEN_ARCH_NAME = ARCH === "x64" ? "X64" : ARCH === "arm64" ? "arm64" : "other";
-const BINARYEN_TAR_NAME = `binaryen-${BINARYEN_SYSTEM_NAME}-${BINARYEN_ARCH_NAME}.tar.gz`;
-await download(`https://github.com/near/binaryen/releases/download/${BINARYEN_VERSION_TAG}/${BINARYEN_TAR_NAME}`);
-fs.mkdirSync("binaryen");
-await executeCommand(`tar xvf ${BINARYEN_TAR_NAME} --directory binaryen`);
-fs.rmSync(BINARYEN_TAR_NAME);
 signale.await("Installing QuickJS...");
 const QUICK_JS_VERSION = `0.1.3`;
 const QUICK_JS_VERSION_TAG = `v${QUICK_JS_VERSION}`;

--- a/packages/near-sdk-js/src/cli/cli.ts
+++ b/packages/near-sdk-js/src/cli/cli.ts
@@ -239,9 +239,6 @@ export async function transpileJsAndBuildWasmCom(
     verbose
   );
 
-  signale.await("Executing wasi-stub...");
-  await wasiStubContract(getContractTarget(target), verbose);
-
   signale.success(
     `Generated ${getContractTarget(target)} contract successfully!`
   );
@@ -363,7 +360,7 @@ async function createWasmContract(
 ) {
   const WASI_SDK_PATH = `${NEAR_SDK_JS}/lib/cli/deps/wasi-sdk`;
 
-  const CC = `${WASI_SDK_PATH}/bin/clang --sysroot=${WASI_SDK_PATH}/share/wasi-sysroot`;
+  const CC = `${WASI_SDK_PATH}/bin/clang`;
   let DEFS = `-D_GNU_SOURCE '-DCONFIG_VERSION="2021-03-27"' -DCONFIG_BIGNUM`;
 
   if (process.env.NEAR_NIGHTLY) {
@@ -382,14 +379,9 @@ async function createWasmContract(
   fs.renameSync(qjscTarget, "build/code.h");
 
   await executeCommand(
-    `${CC} --target=wasm32-wasi -nostartfiles -Oz -flto ${DEFS} ${INCLUDES} ${SOURCES} ${LIBS} -Wl,--no-entry -Wl,--allow-undefined -Wl,-z,stack-size=${
-      256 * 1024
-    } -Wl,--lto-O3 -o ${contractTarget}`,
+    `${CC} -mcpu=mvp -Oz -fno-strict-aliasing ${DEFS} ${INCLUDES} ${SOURCES} ${LIBS} -mexec-model=reactor -Wl,--allow-undefined -Wl,--stack-first,-z,stack-size=${
+      256 * 1024 * 2
+    } -Wl,--compress-relocations,--strip-debug -o ${contractTarget}`,
     verbose
   );
-}
-
-async function wasiStubContract(contractTarget: string, verbose = false) {
-  const WASI_STUB = `${NEAR_SDK_JS}/lib/cli/deps/binaryen/wasi-stub/run.sh`;
-  await executeCommand(`${WASI_STUB} ${contractTarget}`, verbose);
 }

--- a/packages/near-sdk-js/src/cli/post-install.ts
+++ b/packages/near-sdk-js/src/cli/post-install.ts
@@ -31,34 +31,6 @@ if (!SUPPORTED_ARCH.includes(ARCH)) {
   process.exit(1);
 }
 
-signale.await("Installing wasi-stub...");
-
-const BINARYEN_VERSION = `0.1.15`;
-const BINARYEN_VERSION_TAG = `v${BINARYEN_VERSION}`;
-
-const BINARYEN_SYSTEM_NAME =
-  PLATFORM === "linux"
-    ? "Linux"
-    : PLATFORM === "darwin"
-    ? "macOS"
-    : PLATFORM === "win32"
-    ? "windows"
-    : "other";
-
-const BINARYEN_ARCH_NAME =
-  ARCH === "x64" ? "X64" : ARCH === "arm64" ? "arm64" : "other";
-
-const BINARYEN_TAR_NAME = `binaryen-${BINARYEN_SYSTEM_NAME}-${BINARYEN_ARCH_NAME}.tar.gz`;
-
-await download(
-  `https://github.com/near/binaryen/releases/download/${BINARYEN_VERSION_TAG}/${BINARYEN_TAR_NAME}`
-);
-
-fs.mkdirSync("binaryen");
-
-await executeCommand(`tar xvf ${BINARYEN_TAR_NAME} --directory binaryen`);
-fs.rmSync(BINARYEN_TAR_NAME);
-
 signale.await("Installing QuickJS...");
 
 const QUICK_JS_VERSION = `0.1.3`;


### PR DESCRIPTION
🚨Attention: before merging, this patch needs to be squashed with a future commit which changes where we fetch wasi-sdk binaries, now we need to fetch from a near fork of wasi-sdk.

This patch includes improvements as suggested in the last report. Most notably, it drops a very legacy version of wasi-sdk and is able to make use of latest wasi-sdk. The wasi-sdk patch makes things work out of the box for the near platform, allowing the wasi-stub hack to be dropped here as well, so no need to maintain a binaryen fork either.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript SDK here: https://github.com/near/near-sdk-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-sdk-js/blob/master/CONTRIBUTING.md).
- [ ] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
