### PR TITLE
fix: fix near-contract-standards event emission

### DIFF
--- a/packages/near-contract-standards/src/fungible_token/events.ts
+++ b/packages/near-contract-standards/src/fungible_token/events.ts
@@ -18,19 +18,24 @@
 import { NearEvent } from "../event";
 import { Option } from "../non_fungible_token/utils";
 import { AccountId, Balance } from "near-sdk-js";
+import { toSnakeCase } from "../util";
 
 export type Nep141EventKind = FtMint[] | FtTransfer[] | FtBurn[];
 
 export class Nep141Event extends NearEvent {
-    version: string;
-    event_kind: Nep141EventKind;
+  standard: string;
+  version: string;
+  event: string;
+  data: Nep141EventKind;
 
-    constructor(version: string, event_kind: Nep141EventKind) {
-      super();
-      this.version = version;
-      this.event_kind = event_kind;
-    }
+  constructor(version: string, event_kind: Nep141EventKind) {
+    super();
+    this.standard = "nep141"
+    this.version = version
+    this.event = toSnakeCase(event_kind[0].constructor.name)
+    this.data = event_kind
   }
+}
 
 /** Data to log for an FT mint event. To log this event, call [`.emit()`](FtMint::emit). */
 export class FtMint {

--- a/packages/near-contract-standards/src/non_fungible_token/events.ts
+++ b/packages/near-contract-standards/src/non_fungible_token/events.ts
@@ -16,17 +16,22 @@
 import { AccountId } from "near-sdk-js";
 import { NearEvent } from "../event";
 import { TokenId } from "./token";
+import { toSnakeCase } from "../util";
 
 export type Nep171EventKind = NftMint[] | NftTransfer[] | NftBurn[];
 
 export class Nep171Event extends NearEvent {
+  standard: string;
   version: string;
-  event_kind: Nep171EventKind;
+  event: string;
+  data: Nep171EventKind;
 
   constructor(version: string, event_kind: Nep171EventKind) {
     super();
-    this.version = version;
-    this.event_kind = event_kind;
+    this.standard = "nep171"
+    this.version = version
+    this.event = toSnakeCase(event_kind[0].constructor.name)
+    this.data = event_kind
   }
 }
 

--- a/packages/near-contract-standards/src/util.ts
+++ b/packages/near-contract-standards/src/util.ts
@@ -1,0 +1,3 @@
+export const toSnakeCase = (str: string) => {
+  return str.replace(/[A-Z]/g, (letter, index) => { return index == 0 ? letter.toLowerCase() : '_'+ letter.toLowerCase();});
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript SDK here: https://github.com/near/near-sdk-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [V] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-sdk-js/blob/master/CONTRIBUTING.md).
- [V] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation
fungible token, non fungible token contracts in near-contract-standards folder doesn't emit nep141 & nep171 event.
<img width="1155" alt="image" src="https://github.com/near/near-sdk-js/assets/8237090/5807dcf5-6d3d-404b-9f66-df2c7da5a8e8">

It seems that the code found in the near-contract-standards folder attempts to directly convert near-sdk-rs contracts to TypeScript. However, since it disregards Rust's serde tags and related annotations, there is an issue when emitting events through this contract code, as it doesn't properly track them as nep141 or nep171 events.

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
