### PR TITLE
Add build method in promise api to allow execute promise without return it

### DIFF
--- a/packages/near-sdk-js/lib/promise.d.ts
+++ b/packages/near-sdk-js/lib/promise.d.ts
@@ -370,6 +370,12 @@ export declare class NearPromise {
      * Called by NearBindgen, when return object is a NearPromise instance.
      */
     onReturn(): void;
+    /**
+     * Attach the promise to transaction but does not return it. The promise will be executed, but
+     * whether it success or not will not affect the transaction result. If you want the promise fail
+     * also makes the transaction fail, you can simply return the promise from a @call method.
+     */
+    build(): PromiseIndex;
 }
 export declare type PromiseOrValue<T> = NearPromise | T;
 export {};

--- a/packages/near-sdk-js/lib/promise.js
+++ b/packages/near-sdk-js/lib/promise.js
@@ -484,4 +484,12 @@ export class NearPromise {
     onReturn() {
         this.asReturn().constructRecursively();
     }
+    /**
+     * Attach the promise to transaction but does not return it. The promise will be executed, but
+     * whether it success or not will not affect the transaction result. If you want the promise fail
+     * also makes the transaction fail, you can simply return the promise from a @call method.
+     */
+    build() {
+        return this.constructRecursively();
+    }
 }

--- a/packages/near-sdk-js/src/promise.ts
+++ b/packages/near-sdk-js/src/promise.ts
@@ -645,6 +645,15 @@ export class NearPromise {
   onReturn() {
     this.asReturn().constructRecursively();
   }
+
+  /**
+   * Attach the promise to transaction but does not return it. The promise will be executed, but
+   * whether it success or not will not affect the transaction result. If you want the promise fail
+   * also makes the transaction fail, you can simply return the promise from a @call method.
+   */
+  build(): PromiseIndex {
+    return this.constructRecursively();
+  }
 }
 
 export type PromiseOrValue<T> = NearPromise | T;

--- a/tests/__tests__/test_highlevel_promise.ava.js
+++ b/tests/__tests__/test_highlevel_promise.ava.js
@@ -349,3 +349,33 @@ test("highlevel promise and", async (t) => {
     }
   );
 });
+
+test("highlevel promise not build and not return", async (t) => {
+  const { bob, highlevelPromise } = t.context.accounts;
+
+  let r = await bob.callRaw(highlevelPromise, "not_return_not_build", "", {
+    gas: "100 Tgas",
+  });
+
+  try {
+    let balance = await highlevelPromise.getSubAccount("b").balance();
+  } catch (e) {
+    t.is(e.type, "AccountDoesNotExist");
+  }
+});
+
+test("highlevel promise build and not return", async (t) => {
+  const { bob, highlevelPromise } = t.context.accounts;
+
+  let r = await bob.callRaw(highlevelPromise, "build_not_return", "", {
+    gas: "100 Tgas",
+  });
+  t.is(
+    r.result.receipts_outcome[1].outcome.executor_id,
+    highlevelPromise.getSubAccount("b").accountId
+  );
+  t.is(r.result.receipts_outcome[1].outcome.status.SuccessValue, "");
+
+  let balance = await highlevelPromise.getSubAccount("b").balance();
+  t.is(balance.total.toString(), "10000000000000000000000000");
+});

--- a/tests/src/highlevel-promise.js
+++ b/tests/src/highlevel-promise.js
@@ -263,4 +263,21 @@ export class HighlevelPromiseContract {
       );
     return promise;
   }
+
+  @call({})
+  not_return_not_build() {
+    // let promise = NearPromise.new("b.highlevel-promise.test.near")
+    //   .createAccount()
+    //   .transfer(10000000000000000000000000n);
+    // nothing happens
+  }
+
+  @call({})
+  build_not_return() {
+    let promise = NearPromise.new("b.highlevel-promise.test.near")
+      .createAccount()
+      .transfer(10000000000000000000000000n);
+    promise.build();
+    // doesn't return the promise, but promise should be created and executed
+  }
 }


### PR DESCRIPTION
Fix #387 

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript SDK here: https://github.com/near/near-sdk-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-sdk-js/blob/master/CONTRIBUTING.md).
- [ ] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
