### PR TITLE
Use deserializer from options if specified within getValueWithOptions function

### DIFF
--- a/packages/near-sdk-js/lib/utils.js
+++ b/packages/near-sdk-js/lib/utils.js
@@ -31,14 +31,13 @@ export function assert(expression, message) {
         throw new Error("assertion failed: " + message);
     }
 }
-export function getValueWithOptions(subDatatype, value, options = {
-    deserializer: deserialize,
-}) {
+export function getValueWithOptions(subDatatype, value, options = {}) {
     if (value === null) {
         return options?.defaultValue ?? null;
     }
+    const deserializer = options.deserializer || deserialize;
     // here is an obj
-    let deserialized = deserialize(value);
+    let deserialized = deserializer(value);
     if (deserialized === undefined || deserialized === null) {
         return options?.defaultValue ?? null;
     }

--- a/packages/near-sdk-js/src/utils.ts
+++ b/packages/near-sdk-js/src/utils.ts
@@ -69,16 +69,16 @@ export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
 export function getValueWithOptions<DataType>(
   subDatatype: unknown,
   value: Uint8Array | null,
-  options: Omit<GetOptions<DataType>, "serializer"> = {
-    deserializer: deserialize,
-  }
+  options: Omit<GetOptions<DataType>, "serializer"> = {}
 ): DataType | null {
   if (value === null) {
     return options?.defaultValue ?? null;
   }
 
+  const deserializer = options.deserializer || deserialize;
+
   // here is an obj
-  let deserialized = deserialize(value);
+  let deserialized = deserializer(value);
 
   if (deserialized === undefined || deserialized === null) {
     return options?.defaultValue ?? null;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript SDK here: https://github.com/near/near-sdk-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-sdk-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Custom deserializer provided into options isn't respected while querying data from LookupMap, Vector, etc

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
