### PR TITLE
docs: add CLI usage example for building and deploying contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ Use [`create-near-app`](https://github.com/near/create-near-app) to quickly get 
 
 This will scaffold a basic template for you 😎
 
+### Building and Deploying via CLI
+
+Once you have a contract, build it and deploy using the [NEAR CLI](https://docs.near.org/tools/near-cli):
+
+```bash
+# Build the contract
+npx near-sdk-js build src/contract.ts build/contract.wasm
+
+# Create a NEAR testnet account (if you don't have one)
+near create-account my-contract.testnet --useFaucet
+
+# Deploy the contract
+near deploy my-contract.testnet build/contract.wasm
+
+# Call a view method (free, no gas required)
+near view my-contract.testnet get_greeting
+
+# Call a change method (requires gas)
+near call my-contract.testnet set_greeting '{"greeting": "Hi!"}' --accountId your-account.testnet
+```
+
 ## Contributing
 
 If you are interested in contributing, please look at the [contributing guidelines](https://github.com/near/near-sdk-js/tree/develop/CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
- Add a "Building and Deploying via CLI" subsection to the Quick Start section in README.md
- Shows the full workflow: build with `near-sdk-js`, create a testnet account, deploy, and call view/change methods using NEAR CLI

This addresses the gap where new developers have a contract example but no guidance on how to actually build and deploy it from the command line.

Closes #426

## Test plan
- [ ] Verify CLI commands are accurate against current NEAR CLI
- [ ] Verify the section renders correctly in GitHub markdown