### PR TITLE
fix: add missing ft_metadata view function to fungible token example

### DIFF
--- a/examples/src/fungible-token/my-ft.ts
+++ b/examples/src/fungible-token/my-ft.ts
@@ -6,6 +6,7 @@ import {
     FungibleTokenResolver,
     FungibleToken,
     FungibleTokenMetadata,
+    FungibleTokenMetadataProvider,
 } from "near-contract-standards/lib"; //TODO: delete lib
 
 import {
@@ -31,7 +32,7 @@ class FTPrefix implements IntoStorageKey {
 }
 
 @NearBindgen({ requireInit: true })
-export class MyFt implements FungibleTokenCore, StorageManagement, FungibleTokenResolver {
+export class MyFt implements FungibleTokenCore, StorageManagement, FungibleTokenResolver, FungibleTokenMetadataProvider {
     token: FungibleToken;
     metadata: FungibleTokenMetadata;
 
@@ -123,6 +124,11 @@ export class MyFt implements FungibleTokenCore, StorageManagement, FungibleToken
     @view({})
     ft_balance_of({ account_id }: { account_id: AccountId }): Balance {
         return this.token.ft_balance_of({ account_id });
+    }
+
+    @view({})
+    ft_metadata(): FungibleTokenMetadata {
+        return this.metadata;
     }
 
     @call({ payableFunction: true })


### PR DESCRIPTION
## Summary
- The `my-ft` example defines and stores `FungibleTokenMetadata` but never exposes it via a view function, violating [NEP-148](https://nomicon.io/Standards/Tokens/FungibleToken/Metadata)
- Add `ft_metadata()` view function and implement `FungibleTokenMetadataProvider` interface
- Follows the same pattern used by the NFT example (`my-nft.ts` line 173)

**File:** `examples/src/fungible-token/my-ft.ts`

Fixes #415

## Test plan
- [ ] Build the example: `pnpm build`
- [ ] Call `ft_metadata` on a deployed instance — should return the metadata object
- [ ] Existing FT tests pass