### PR TITLE
fix: return strings from NFT enumeration supply methods

### DIFF
--- a/examples/__tests__/standard-nft/test_enumeration.ava.js
+++ b/examples/__tests__/standard-nft/test_enumeration.ava.js
@@ -86,7 +86,7 @@ test("Enumerate NFT tokens total supply", async (t) => {
   const { nft } = t.context.accounts;
 
   let totalSupply = await nft.view("nft_total_supply");
-  t.is(totalSupply, 4);
+  t.is(totalSupply, "4");
 });
 
 test("Enumerate NFT tokens", async (t) => {
@@ -110,12 +110,12 @@ test("Enumerate NFT tokens supply for owner", async (t) => {
   let aliNfts = await nft.view("nft_supply_for_owner", {
     account_id: ali.accountId,
   });
-  t.is(aliNfts, 0);
+  t.is(aliNfts, "0");
 
   let ownerNfts = await nft.view("nft_supply_for_owner", {
     account_id: nftOwner.accountId,
   });
-  t.is(ownerNfts, 4);
+  t.is(ownerNfts, "4");
 });
 
 test("Enumerate NFT tokens for owner", async (t) => {

--- a/examples/src/non-fungible-token/my-nft.ts
+++ b/examples/src/non-fungible-token/my-nft.ts
@@ -71,7 +71,7 @@ export class MyNFT
   }
 
   @view({})
-  nft_total_supply(): number {
+  nft_total_supply(): string {
     return this.tokens.nft_total_supply();
   }
 
@@ -87,7 +87,7 @@ export class MyNFT
   }
 
   @view({})
-  nft_supply_for_owner({ account_id }: { account_id: string }): number {
+  nft_supply_for_owner({ account_id }: { account_id: string }): string {
     return this.tokens.nft_supply_for_owner({ account_id });
   }
 

--- a/packages/near-contract-standards/src/non_fungible_token/enumeration/index.ts
+++ b/packages/near-contract-standards/src/non_fungible_token/enumeration/index.ts
@@ -3,8 +3,8 @@ import { Token } from "../token";
 
 /** Offers methods helpful in determining account ownership of NFTs and provides a way to page through NFTs per owner, determine total supply, etc. */
 export interface NonFungibleTokenEnumeration {
-  /** Returns the total supply of non-fungible tokens */
-  nft_total_supply(): number;
+  /** Returns the total supply of non-fungible tokens as a string per NEP-181 */
+  nft_total_supply(): string;
 
   /** Get a list of all tokens
    *
@@ -23,9 +23,9 @@ export interface NonFungibleTokenEnumeration {
   /** Get number of tokens owned by a given account
    *
    * @param account_id - A valid NEAR account
-   * @returns - The number of non-fungible tokens owned by given `account_id`
+   * @returns - The number of non-fungible tokens owned by given `account_id` as a string per NEP-181
    */
-  nft_supply_for_owner({ account_id }: { account_id: AccountId }): number;
+  nft_supply_for_owner({ account_id }: { account_id: AccountId }): string;
 
   /** Get list of all tokens owned by a given account
    *

--- a/packages/near-contract-standards/src/non_fungible_token/impl.ts
+++ b/packages/near-contract-standards/src/non_fungible_token/impl.ts
@@ -85,8 +85,8 @@ export class NonFungibleToken
     this.next_approval_id_by_id = null;
   }
 
-  nft_total_supply(): number {
-    return this.owner_by_id.length;
+  nft_total_supply(): string {
+    return this.owner_by_id.length.toString();
   }
 
   private enum_get_token(owner_id: AccountId, token_id: TokenId): Token {
@@ -123,7 +123,7 @@ export class NonFungibleToken
     return ret;
   }
 
-  nft_supply_for_owner({ account_id }: { account_id: AccountId }): number {
+  nft_supply_for_owner({ account_id }: { account_id: AccountId }): string {
     const tokens_per_owner = this.tokens_per_owner;
     assert(
       tokens_per_owner !== null,
@@ -133,7 +133,7 @@ export class NonFungibleToken
     const account_tokens = tokens_per_owner.get(account_id, {
       reconstructor: UnorderedSet.reconstruct,
     });
-    return account_tokens === null ? 0 : account_tokens.length;
+    return account_tokens === null ? "0" : account_tokens.length.toString();
   }
 
   nft_tokens_for_owner({


### PR DESCRIPTION
NEP-181 specifies that nft_total_supply and nft_supply_for_owner return U128 values serialized as JSON strings, but the implementation was returning plain numbers. This changes both methods to return strings via .toString(), matching the standard and preventing potential precision issues with large token counts.

Fixes #416